### PR TITLE
use byte strings for Structs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+
+## Fixed
+- Change struct to use byte strings, to fix a std lib issue
+
 ## [0.1.8] - 2017-06-01
 
 ## Added

--- a/compliance/runtests.py
+++ b/compliance/runtests.py
@@ -4,9 +4,11 @@ from __future__ import unicode_literals
 import logging
 import sys
 import json
+from urllib import urlencode
 
 from lomond import WebSocket
 from lomond.constants import USER_AGENT
+
 
 server = 'ws://127.0.0.1:9001'
 
@@ -54,7 +56,8 @@ def run_ws(url):
 
 def run_test(test_no):
     """Run a test from its index."""
-    url = server + '/runCase?case={}&agent={}'.format(test_no, USER_AGENT)
+    qs = urlencode({'case': test_no, 'agent': USER_AGENT})
+    url = server + '/runCase?{}'.format(qs)
     run_ws(url)
 
 
@@ -62,7 +65,8 @@ def run_test_cases(case_tuples):
     """Run a number of test cases from their 'case tuple'"""
     for case_tuple in case_tuples:
         print("\n[{}]".format(case_tuple))
-        url = server + '/runCase?casetuple={}&agent={}'.format(case_tuple, USER_AGENT)
+        qs = urlencode({'agent': USER_AGENT})
+        url = server + '/runCase?{}'.format(qs)
         run_ws(url)
     update_report()
 
@@ -70,7 +74,8 @@ def run_test_cases(case_tuples):
 def update_report():
     """Tell wstest to update reports."""
     print("Updating reports...")
-    url = server + "/updateReports?agent=" + USER_AGENT
+    qs = urlencode({'agent': USER_AGENT})
+    url = server + "/updateReports?{}".format(qs)
     for _ in WebSocket(url):
         pass
 

--- a/lomond/_version.py
+++ b/lomond/_version.py
@@ -1,3 +1,3 @@
 from __future__ import unicode_literals
 
-__version__ = "0.1.8"
+__version__ = "0.1.9a0"

--- a/lomond/frame.py
+++ b/lomond/frame.py
@@ -6,6 +6,7 @@ A websocket 'message' may consist of several of these frames.
 """
 
 from __future__ import print_function
+from __future__ import unicode_literals
 
 import struct
 
@@ -44,10 +45,10 @@ class Frame(object):
         return len(self.payload)
 
     # Use struct module to pack ws frame header
-    _pack8 = struct.Struct('!BB4s').pack  # 8 bit length field
-    _pack16 = struct.Struct('!BBH4s').pack  # 16 bit length field
-    _pack64 = struct.Struct('!BBQ4s').pack  # 64 bit length field
-    _pack_close_code = struct.Struct('!H').pack
+    _pack8 = struct.Struct(b'!BB4s').pack  # 8 bit length field
+    _pack16 = struct.Struct(b'!BBH4s').pack  # 16 bit length field
+    _pack64 = struct.Struct(b'!BBQ4s').pack  # 64 bit length field
+    _pack_close_code = struct.Struct(b'!H').pack
 
     @classmethod
     def build(cls, opcode, payload=b'', fin=1, rsv1=0, rsv2=0, rsv3=0):

--- a/lomond/frame_parser.py
+++ b/lomond/frame_parser.py
@@ -3,6 +3,8 @@ Parse a stream of Websocket frames, and optional HTTP headers.
 
 """
 
+from __future__ import unicode_literals
+
 import logging
 import struct
 
@@ -17,8 +19,8 @@ log = logging.getLogger('lomond')
 class FrameParser(Parser):
     """Parses a stream of data in to HTTP headers + WS frames."""
 
-    unpack16 = struct.Struct('!H').unpack
-    unpack64 = struct.Struct('!Q').unpack
+    unpack16 = struct.Struct(b'!H').unpack
+    unpack64 = struct.Struct(b'!Q').unpack
 
     def __init__(self, frame_class=Frame, parse_headers=True):
         self._frame_class = frame_class

--- a/lomond/message.py
+++ b/lomond/message.py
@@ -22,7 +22,7 @@ class Message(object):
     """
 
     __slots__ = ['opcode']
-    _unpack16 = struct.Struct('!H').unpack
+    _unpack16 = struct.Struct(b'!H').unpack
 
     def __init__(self, opcode):
         self.opcode = opcode


### PR DESCRIPTION
**What this PR solves**

- At least one version of Raspian has a Python stdlib that complains when Struct objects are passed a unicode string.

**How it is done**

- Make some strings explicit bytes.

**What to look out for**

-

**Screenshots (if appropriate)**

-

**Review**

- [x] Ready for review
