### PR TITLE
Max pong

### DIFF
--- a/lomond/events.py
+++ b/lomond/events.py
@@ -147,9 +147,10 @@ class Ready(Event):
 
 
 class Unresponsive(Event):
-    """The server has not responding to pings within `max_ping` seconds.
+    """The server has not responding to pings within `ping_timeout`
+    seconds.
 
-    Will be followed by a disconnect.
+    Will be followed by a Disconnected event.
 
     """
     name = 'unresponsive'

--- a/lomond/events.py
+++ b/lomond/events.py
@@ -146,6 +146,15 @@ class Ready(Event):
         )
 
 
+class Unresponsive(Event):
+    """The server has not responding to pings within `max_ping` seconds.
+
+    Will be followed by a disconnect.
+
+    """
+    name = 'unresponsive'
+
+
 class Disconnected(Event):
     """Generated when a websocket connection has
     been dropped.

--- a/lomond/persist.py
+++ b/lomond/persist.py
@@ -25,10 +25,10 @@ def persist(websocket, poll=5,
         attempts (seconds).
     :param float ping_rate: Delay between pings (seconds), or `0` for no
         auto ping.
-    :param float ping_timeout: Maximum time to wait for a pong response
-        before disconnecting. Set to `None` (default) to disable.
-        If set, the value should be greater than the `ping_rate`,
-        double `ping_rate` would be a good starting point.
+    :param float ping_timeout: Maximum time in seconds to wait for a
+        pong response before disconnecting. Set to `None` (default) to
+        disable. If set, double `ping_rate` would be a good starting
+        point.
     :param exit_event: A threading event object, which can be used to
         exit the persist loop if it is set. Set to `None` to use an
         internal event object.

--- a/lomond/persist.py
+++ b/lomond/persist.py
@@ -13,7 +13,7 @@ from . import events
 
 def persist(websocket, poll=5,
             min_wait=5, max_wait=30,
-            ping_rate=30, exit_event=None):
+            ping_rate=30, ping_timeout=None, exit_event=None):
     """Run a websocket, with a retry mechanism and exponential back-off.
 
     :param websocket: A :class:`~lomond.websocket.Websocket` instance.
@@ -35,7 +35,8 @@ def persist(websocket, poll=5,
     random_wait = max_wait - min_wait
     while True:
         retries += 1
-        for event in websocket.connect(poll=poll, ping_rate=ping_rate):
+        for event in websocket.connect(
+                poll=poll, ping_rate=ping_rate, ping_timeout=ping_timeout):
             if event.name == 'ready':
                 # The server accepted the WS upgrade.
                 retries = 0

--- a/lomond/persist.py
+++ b/lomond/persist.py
@@ -13,7 +13,8 @@ from . import events
 
 def persist(websocket, poll=5,
             min_wait=5, max_wait=30,
-            ping_rate=30, ping_timeout=None, exit_event=None):
+            ping_rate=30, ping_timeout=None,
+            exit_event=None):
     """Run a websocket, with a retry mechanism and exponential back-off.
 
     :param websocket: A :class:`~lomond.websocket.Websocket` instance.
@@ -24,6 +25,10 @@ def persist(websocket, poll=5,
         attempts (seconds).
     :param float ping_rate: Delay between pings (seconds), or `0` for no
         auto ping.
+    :param float ping_timeout: Maximum time to wait for a pong response
+        before disconnecting. Set to `None` (default) to disable.
+        If set, the value should be greater than the `ping_rate`,
+        double `ping_rate` would be a good starting point.
     :param exit_event: A threading event object, which can be used to
         exit the persist loop if it is set. Set to `None` to use an
         internal event object.

--- a/lomond/session.py
+++ b/lomond/session.py
@@ -151,7 +151,8 @@ class WebsocketSession(object):
     def _check_poll(self, poll):
         """Check if it is time for a poll."""
         current_time = self._time
-        if current_time - self._poll_start >= poll:
+        if (self._poll_start is None or
+            current_time - self._poll_start >= poll):
             self._poll_start = current_time
             return True
         else:
@@ -250,7 +251,6 @@ class WebsocketSession(object):
         """Called when a ready event is received."""
         self._last_pong = 0.0
         self._next_ping = 0.0
-        self._poll_start = 0.0
         self._start_time = time.time()
 
     def run(self,
@@ -313,8 +313,9 @@ class WebsocketSession(object):
                             break
                         else:
                             self._socket_fail('connection lost')
-                    for event in self._feed(data, poll, ping_rate,
-                                            ping_timeout, close_timeout):
+                    for event in self._feed(data, poll,
+                                            ping_rate, ping_timeout,
+                                            close_timeout):
                         if event.name == 'ready':
                             self._on_ready()
                             ready = True

--- a/lomond/session.py
+++ b/lomond/session.py
@@ -163,6 +163,7 @@ class WebsocketSession(object):
         if ping_rate:
             current_time = self._time
             if current_time > self._next_ping:
+                # Calculate next ping time that is in the future.
                 self._next_ping = (
                     math.ceil(current_time / ping_rate) * ping_rate
                 )

--- a/lomond/websocket.py
+++ b/lomond/websocket.py
@@ -150,7 +150,7 @@ class WebSocket(object):
                 close_timeout=30.0):
         """Connect the websocket to a session.
 
-       :param session_class: An object to manage the *session*. This
+        :param session_class: An object to manage the *session*. This
             object is an extension mechanism that will allow the
             WebSocket to be *driven* by different back-ends. For now,
             treat it as an implementation detail and leave it as the
@@ -159,10 +159,10 @@ class WebSocket(object):
             generated.
         :param float ping_rate: Rate that ping packets should be sent.
             Set to `0` to disable auto pings.
-        :param float ping_timeout: Maximum time to wait for a pong response
-            before disconnecting. Set to `None` (default) to disable.
-            If set, the value should be greater than the `ping_rate`,
-            double `ping_rate` would be a good starting point.
+        :param float ping_timeout: Maximum time in seconds to wait for a
+            pong response before disconnecting. Set to `None` (default)
+            to disable. If set, double `ping_rate` would be a good
+            starting point.
         :param bool auto_pong: Enable (default) automatic response to
             ping events.
         :param float close_timeout: Seconds to wait for server to

--- a/lomond/websocket.py
+++ b/lomond/websocket.py
@@ -145,11 +145,12 @@ class WebSocket(object):
                 session_class=WebsocketSession,
                 poll=5.0,
                 ping_rate=30.0,
+                ping_timeout=None,
                 auto_pong=True,
                 close_timeout=30.0):
         """Connect the websocket to a session.
 
-        :param session_class: An object to manage the *session*. This
+       :param session_class: An object to manage the *session*. This
             object is an extension mechanism that will allow the
             WebSocket to be *driven* by different back-ends. For now,
             treat it as an implementation detail and leave it as the
@@ -158,6 +159,10 @@ class WebSocket(object):
             generated.
         :param float ping_rate: Rate that ping packets should be sent.
             Set to `0` to disable auto pings.
+        :param float ping_timeout: Maximum time to wait for a pong response
+            before disconnecting. Set to `None` (default) to disable.
+            If set, the value should be greater than the `ping_rate`,
+            double `ping_rate` would be a good starting point.
         :param bool auto_pong: Enable (default) automatic response to
             ping events.
         :param float close_timeout: Seconds to wait for server to
@@ -171,6 +176,7 @@ class WebSocket(object):
         run_coro = session.run(
             poll=poll,
             ping_rate=ping_rate,
+            ping_timeout=ping_timeout,
             auto_pong=auto_pong,
             close_timeout=close_timeout
         )

--- a/tests/test_persist.py
+++ b/tests/test_persist.py
@@ -8,7 +8,7 @@ class FakeEvent(object):
 
 
 class FakeWebSocket(object):
-    def connect(self, poll=None, ping_rate=None):
+    def connect(self, poll=None, ping_rate=None, ping_timeout=None):
         yield events.Connecting('ws://localhost:1234/')
         yield events.ConnectFail('test')
 
@@ -52,7 +52,7 @@ def test_persist_with_nonexisting_server(mocker):
 
 
 def test_emulate_ready_event(mocker):
-    def successful_connect(poll=None, ping_rate=None):
+    def successful_connect(poll=None, ping_rate=None, ping_timeout=None):
         yield events.Connecting('ws://localhost:1234')
         yield events.Ready(None, None, None)
 

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -340,16 +340,6 @@ def test_simple_run(monkeypatch, mocker):
     # location. Here's how we do it:
     session._regular_orig = session._regular
 
-    # def _regular_with_fake_poll_start(self, poll, ping_rate, ping_timeout, close_timeout):
-    #     # trivial substitute:
-    #     self._poll_start = self._last_ping
-    #     # print(self._regular_orig)
-    #     return self._regular_orig(poll, ping_rate, ping_timeout, close_timeout)
-
-    # mocker.patch(
-    #     'lomond.session.WebsocketSession._regular',
-    #     _regular_with_fake_poll_start
-    # )
     mocker.patch(
         'lomond.websocket.WebSocket._send_close')
     mocker.patch.object(session.websocket, 'send_ping')

--- a/tox.ini
+++ b/tox.ini
@@ -19,7 +19,6 @@ deps =
     pytest
     pytest-cov
     pytest-mock
-    pytest-catchlog
     mocket
     freezegun
     wsaccel: wsaccel


### PR DESCRIPTION
# Ready for review

**What this PR solves**

- Adds a ping_timeout parameter which specifies the maximum number of seconds between pongs before the connection is assumed to be unresponsive.
- Tested with a real server, and autobahn test suite

**How it is done**

-

**What to look out for**

-

**Screenshots (if appropriate)**

-

**Review**

- [x] Ready for review
