### PR TITLE
Add support for http proxies

### DIFF
--- a/lomond/proxy.py
+++ b/lomond/proxy.py
@@ -5,9 +5,11 @@ Http proxy support
 from __future__ import print_function
 from __future__ import unicode_literals
 
+import base64
 from collections import namedtuple
 
 import six
+from six.moves import range
 from six.moves.urllib.parse import urlparse
 
 
@@ -47,3 +49,75 @@ class ProxyInfo(namedtuple('ProxyInfo', 'host port credentials')):
                 raise ValueError('illegal proxy url')
 
         return cls(host=host, port=port, credentials=credentials)
+
+
+class ProxyConnectionError(Exception):
+    """
+    Raised due to issues while dealing with the proxy
+    """
+
+
+def issue_proxy_connect(proxy_sock, target_host, target_port, credentials=None):
+    """
+    Takes a socket connected to a proxy and issues a `CONNECT` request,
+    processing the response afterwards.
+    If `credentials` is provided, it will be base64-encoded and passed as
+    Basic authentication (so it should be of the form `user:password`)
+    """
+
+    request = [
+        'CONNECT %s:%d HTTP/1.1' % (target_host, target_port),
+        'Host: %s' % target_host,
+        'Proxy-Connection: keep-alive',
+        'Connection: keep-alive',
+    ]
+
+    if credentials:
+        base64_credentials = base64.standard_b64encode(credentials).decode('ascii')
+        request.append('Proxy-Authorization: Basic %s' % base64_credentials)
+
+    request.append('\r\n')
+
+    encoded_request = '\r\n'.join(request).encode('utf-8')
+    proxy_sock.sendall(encoded_request)
+
+    response = read_line(proxy_sock, is_first_line=True)
+    protocol_version, status_code, message = response.split(' ', 2)
+
+    if not protocol_version.startswith('HTTP/'):
+        raise ProxyConnectionError('Bad response (status)')
+
+    if status_code != '200':
+        raise ProxyConnectionError(status_code, message)
+
+
+    response_headers = []
+    for _ in range(128):
+        line = read_line(proxy_sock)
+        if line:
+            response_headers.append(line)
+        else:
+            break
+    else:
+        # Too many headers?
+        raise ProxyConnectionError('Bad response (header too long)')
+
+
+def read_line(sock, is_first_line=False):
+    buf = []
+    for _ in range(4096):
+        c = sock.recv(1)
+        buf.append(c)
+        if not c or c == b'\n':
+            break
+    else:
+        # Line suspiciously long...
+        raise ProxyConnectionError('Bad response (line too long)')
+
+    result = b''.join(buf)
+
+    if not result and is_first_line:
+        raise ProxyConnectionError('Bad response (empty)')
+    if not result.endswith(b'\r\n'):
+        raise ProxyConnectionError('Bad response (line error)')
+    return result.rstrip().decode('utf-8')

--- a/lomond/proxy.py
+++ b/lomond/proxy.py
@@ -1,0 +1,49 @@
+"""
+Http proxy support
+"""
+
+from __future__ import print_function
+from __future__ import unicode_literals
+
+from collections import namedtuple
+
+import six
+from six.moves.urllib.parse import urlparse
+
+
+class ProxyInfo(namedtuple('ProxyInfo', 'host port credentials')):
+    __slots__ = ()
+
+    @classmethod
+    def parse(cls, proxy_url):
+        host, port, credentials = [None] * 3
+        if proxy_url:
+            _url = urlparse(proxy_url, allow_fragments=False)
+            if not _url.scheme:
+                assert not _url.netloc, _url
+                netloc, slash, path = _url.path.partition('/')
+                path = slash + path
+            elif _url.scheme == 'http':
+                netloc = _url.netloc
+                path = _url.path
+            else:
+                raise ValueError('illegal proxy scheme')
+
+            if '@' in netloc:
+                credentials, _, host_port = netloc.partition('@')
+                if isinstance(credentials, six.text_type):
+                    credentials = credentials.encode('ascii')
+            else:
+                host_port = netloc
+
+            host, _, port_str = host_port.partition(':')
+
+            if port_str and not port_str.isdigit():
+                raise ValueError('illegal proxy port value')
+            port = int(port_str or '80')
+
+            invalid_path = path not in ['', '/']
+            if not host or invalid_path or _url.params or _url.query:
+                raise ValueError('illegal proxy url')
+
+        return cls(host=host, port=port, credentials=credentials)

--- a/lomond/session.py
+++ b/lomond/session.py
@@ -108,6 +108,8 @@ class WebsocketSession(object):
 
     def _connect(self):
         """Create socket and connect."""
+        assert not self.websocket.proxy_info.host, 'Proxy not yet supported'
+
         host = self.websocket.host
         sock = connect_socket(host=host, port=self.websocket.port)
         if self.websocket.is_secure:

--- a/lomond/session.py
+++ b/lomond/session.py
@@ -31,7 +31,6 @@ class WebsocketSession(object):
     def __init__(self, websocket):
         self.websocket = websocket
 
-        self._address = (websocket.host, websocket.port)
         self._lock = threading.Lock()
 
         self._sock = None
@@ -109,43 +108,11 @@ class WebsocketSession(object):
 
     def _connect(self):
         """Create socket and connect."""
-        sock = socket.socket(
-            socket.AF_INET, socket.SOCK_STREAM
-        )
-        sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
-        sock.settimeout(30)  # TODO: make a parameter for this?
+        host = self.websocket.host
+        sock = connect_socket(host=host, port=self.websocket.port)
         if self.websocket.is_secure:
-            sock = self._wrap_socket(sock)
-        sock.connect(self._address)
-        # The timeout makes the socket non-blocking
-        # We want to the socket to block after the connection
-        sock.settimeout(None)
+            sock = ssl_wrap_socket(sock, server_hostname=host)
         return sock
-
-    def _wrap_socket(self, sock):
-        """Wrap the socket with an SSL proxy."""
-        # sniff SNI support (added Python 2.7.9)
-        has_sni = (
-            hasattr(ssl, 'SSLContext') and
-            getattr(ssl, 'HAS_SNI', False)
-        )
-        if has_sni:
-            _protocol = getattr(
-                ssl,
-                'PROTOCOL_TLS',  # Supported since 2.7.13
-                ssl.PROTOCOL_SSLv23   # Supported since 2.7.9
-            )
-            ssl_context = ssl.SSLContext(_protocol)
-            ssl_sock = ssl_context.wrap_socket(
-                sock,
-                server_hostname=self.websocket.host
-            )
-        else:
-            # Fallback for no SNI
-            log.warning('no SNI support')
-            ssl_sock = ssl.wrap_socket(sock)
-        return ssl_sock
-
 
     def _close_socket(self):
         """Close the socket safely."""
@@ -373,6 +340,47 @@ class WebsocketSession(object):
             # it was a graceful exit.
             self._close_socket()
             yield events.Disconnected(graceful=True)
+
+
+def connect_socket(host, port):
+    """ Creeate a socket and connect """
+    address = (host, port)
+
+    sock = socket.socket(
+        socket.AF_INET, socket.SOCK_STREAM
+    )
+    sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
+    sock.settimeout(30)  # TODO: make a parameter for this?
+    sock.connect(address)
+    # The timeout makes the socket non-blocking
+    # We want to the socket to block after the connection
+    sock.settimeout(None)
+    return sock
+
+
+def ssl_wrap_socket(sock, server_hostname):
+    """Wrap the socket with an SSL proxy."""
+    # sniff SNI support (added Python 2.7.9)
+    has_sni = (
+        hasattr(ssl, 'SSLContext') and
+        getattr(ssl, 'HAS_SNI', False)
+    )
+    if has_sni:
+        _protocol = getattr(
+            ssl,
+            'PROTOCOL_TLS',  # Supported since 2.7.13
+            ssl.PROTOCOL_SSLv23   # Supported since 2.7.9
+        )
+        ssl_context = ssl.SSLContext(_protocol)
+        ssl_sock = ssl_context.wrap_socket(
+            sock,
+            server_hostname=server_hostname
+        )
+    else:
+        # Fallback for no SNI
+        log.warning('no SNI support')
+        ssl_sock = ssl.wrap_socket(sock)
+    return ssl_sock
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/lomond/websocket.py
+++ b/lomond/websocket.py
@@ -20,6 +20,7 @@ from . import errors
 from . import events
 from .frame import Frame
 from .opcode import Opcode
+from .proxy import ProxyInfo
 from .response import Response
 from .stream import WebsocketStream
 from .session import WebsocketSession
@@ -39,7 +40,8 @@ class WebSocket(object):
     :params str agent: A user agent string to be sent in the header. The
         default uses the value `USER_AGENT` defined in
         :mod:`lomond.constants`.
-
+    :params str proxy_url: An optional proxy URL, e.g.
+        `http://user@pwd:proxy.com:8080/`.
     """
 
     class State(object):
@@ -52,7 +54,7 @@ class WebSocket(object):
             self.closed = False
             self.sent_close_time = None
 
-    def __init__(self, url, protocols=None, agent=None):
+    def __init__(self, url, protocols=None, agent=None, proxy_url=None):
         self.url = url
         self.protocols = protocols or []
         self.agent = agent or constants.USER_AGENT
@@ -73,6 +75,7 @@ class WebSocket(object):
         self.resource = _url.path or '/'
         if _url.query:
             self.resource = "{}?{}".format(self.resource, _url.query)
+        self.proxy_info = ProxyInfo.parse(proxy_url)
 
         self.state = self.State()
 

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -1,0 +1,65 @@
+from lomond.proxy import ProxyInfo
+import pytest
+
+
+proxy_info_parse_ok = [
+    (
+        None,
+        ProxyInfo(host=None, port=None, credentials=None)
+    ),
+    (
+        'http://a-proxy.com',
+        ProxyInfo(host='a-proxy.com', port=80, credentials=None)
+    ),
+    (
+        'http://a-proxy.com:8080/',
+        ProxyInfo(host='a-proxy.com', port=8080, credentials=None)
+    ),
+    (
+        'http://jdoe@a-proxy.com',
+        ProxyInfo(host='a-proxy.com', port=80, credentials=b'jdoe')
+    ),
+    (
+        'http://jdoe@a-proxy.com:8080',
+        ProxyInfo(host='a-proxy.com', port=8080, credentials=b'jdoe')
+    ),
+    (
+        'http://jdoe:qwerty@a-proxy.com:8080/',
+        ProxyInfo(host='a-proxy.com', port=8080, credentials=b'jdoe:qwerty')
+    ),
+    (
+        'a-proxy.com:8888',
+        ProxyInfo(host='a-proxy.com', port=8888, credentials=None)
+    ),
+    (
+        'a-proxy.com',
+        ProxyInfo(host='a-proxy.com', port=80, credentials=None)
+    ),
+    (
+        'jdoe@a-proxy.com',
+        ProxyInfo(host='a-proxy.com', port=80, credentials=b'jdoe')
+    ),
+]
+
+@pytest.mark.parametrize("proxy_url, expected", proxy_info_parse_ok)
+def test_proxy_info_parse_ok(proxy_url, expected):
+    result = ProxyInfo.parse(proxy_url)
+    assert  result == expected
+
+
+proxy_info_parse_failure = [
+    ('https://a-proxy.com/', 'illegal proxy scheme'),
+    ('http://a-proxy.com:a-port/', 'illegal proxy port value'),
+    ('http://a-proxy.com/foo', 'illegal proxy url'),
+    ('http://a-proxy.com/?foo=bar', 'illegal proxy url'),
+    ('http:///', 'illegal proxy url'),
+    ('http://:8080/', 'illegal proxy url'),
+]
+
+
+@pytest.mark.parametrize("proxy_url, expected", proxy_info_parse_failure)
+def test_proxy_info_parse_failure(proxy_url, expected):
+    with pytest.raises(ValueError) as e_info:
+        ProxyInfo.parse(proxy_url)
+
+    assert e_info.value.args == (expected,)

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -1,4 +1,8 @@
+from lomond.proxy import issue_proxy_connect
+from lomond.proxy import ProxyConnectionError
 from lomond.proxy import ProxyInfo
+from test_session import FakeSocket
+
 import pytest
 
 
@@ -63,3 +67,100 @@ def test_proxy_info_parse_failure(proxy_url, expected):
         ProxyInfo.parse(proxy_url)
 
     assert e_info.value.args == (expected,)
+
+
+def test_issue_proxy_connect_no_credentials():
+    expected_request = (
+        b'CONNECT foo.com:80 HTTP/1.1\r\n'
+        b'Host: foo.com\r\n'
+        b'Proxy-Connection: keep-alive\r\n'
+        b'Connection: keep-alive\r\n'
+        b'\r\n'
+    )
+    proxy_sock = FakeSocket(
+        recv_buffer=(
+            b'HTTP/1.0 200 Connection established\r\n'
+            b'Some-header: Yeah\r\n'
+            b'Another-header: Why not\r\n'
+            b'\r\n'
+        )
+    )
+    issue_proxy_connect(proxy_sock, 'foo.com', 80, credentials=None)
+    assert proxy_sock.send_buffer == expected_request
+    assert proxy_sock.recv_buffer == b''
+
+
+def test_issue_proxy_connect_credentials():
+    credentials = b"Aladdin:open sesame"  # example taken from RFC-7617
+    expected_request = (
+        b'CONNECT foo.com:80 HTTP/1.1\r\n'
+        b'Host: foo.com\r\n'
+        b'Proxy-Connection: keep-alive\r\n'
+        b'Connection: keep-alive\r\n'
+        b'Proxy-Authorization: Basic QWxhZGRpbjpvcGVuIHNlc2FtZQ==\r\n'
+        b'\r\n'
+    )
+    proxy_sock = FakeSocket(
+        recv_buffer=(
+            b'HTTP/1.0 200 Connection established\r\n'
+            b'About-your-credentials: Loved them\r\n'
+            b'\r\n'
+        )
+    )
+    issue_proxy_connect(proxy_sock, 'foo.com', 80, credentials=credentials)
+    assert proxy_sock.send_buffer == expected_request
+    assert proxy_sock.recv_buffer == b''
+
+
+
+proxy_error_cases = [
+    (
+        'Bad response (empty)',
+        b''
+    ),
+    (
+        'Bad response (line error)',
+        b'HTTP/1.0 200 Connection established\r\n'
+    ),
+    (
+        'Bad response (line error)',
+        b'HTTP/1.0 200 Connection established\r\n'
+        b'Some-Head'
+    ),
+    (
+        'Bad response (status)',
+        b'220 smtp.server.com Simple Mail Transfer Service Ready\r\n'
+    ),
+    (
+        ('418', "I'm a teapot"),
+        b'HTTP/1.0 418 I\'m a teapot\r\n'
+    ),
+    (
+        'Bad response (line too long)',
+        b'HTTP/1.0 200 Connection established%s\r\n'
+        b'\r\n' % b''.join([b'!'] * 4096)
+    ),
+    (
+        'Bad response (line too long)',
+        b'HTTP/1.0 200 Connection established\r\n'
+        b'GNU: %s...\r\n'
+        b'\r\n' % b''.join([b'GNU is not unix -> '] * 218)
+    ),
+    (
+        'Bad response (header too long)',
+        b'HTTP/1.0 200 Connection established\r\n'
+        b'%s'
+        b'\r\n' % b'\r\n'.join(b'Header-%d: Stuff' % i for i in range(128))
+    )
+]
+
+@pytest.mark.parametrize("expected_error, response", proxy_error_cases)
+def test_issue_proxy_error_handling(response, expected_error):
+    if not isinstance(expected_error, tuple):
+        expected_error = (expected_error,)
+
+    proxy_sock = FakeSocket(recv_buffer=response)
+    with pytest.raises(ProxyConnectionError) as e_info:
+        issue_proxy_connect(proxy_sock, 'foo.com', 80, credentials=None)
+
+    assert e_info.value.args == expected_error


### PR DESCRIPTION
**What this PR solves**

Solves issue #36: one can now specify a `proxy_url` when creating a `WebSocket`. The url is of the form `[http://][user:password@]host[:port][/]`

**How it is done**

We change the implementation of `WebsocketSession._connect()` so that, in case proxy information was provided, a connection is opened to the proxy instead of the websocket server. Then a `CONNECT` message is sent to the proxy and the HTTP response is consumed. If everything goes well, the socket is left in a state where one can do either the TLS handshake for `wss://` or the connection upgrade request.

In case `user:password` information is provided, authentication on the proxy is done using the Basic Authentication Scheme.

**Review**

- [x] Ready for review
