### PR TITLE
specified title per GitHub pages theme settings

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,1 +1,3 @@
 theme: jekyll-theme-cayman
+title: Dataplicity Lomond
+description: A Websocket client for Python which turns a websocket connection in to an orderly stream of events.


### PR DESCRIPTION
**What this PR solves**

- added title and description fields per https://github.com/pages-themes/cayman

**How it is done**

-

**What to look out for**

-

**Screenshots (if appropriate)**

-

**Review**

- [X] Ready for review