### PR TITLE
Propagate error details when socket connection fails.

### DIFF
--- a/lomond/session.py
+++ b/lomond/session.py
@@ -109,12 +109,15 @@ class WebsocketSession(object):
             )
         except socket.error as error:
             self._socket_fail('unable to connect; {}', error)
+
+        sock_err = None
         for res in addr_info:
             af, socktype, proto, canonname, sa = res
             try:
                 sock = socket.socket(af, socktype, proto)
-            except socket.error:
+            except socket.error as error:
                 sock = None
+                sock_err = error
                 continue
             sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
             sock.settimeout(30)  # TODO: make a parameter for this?
@@ -122,13 +125,14 @@ class WebsocketSession(object):
                 sock = self._wrap_socket(sock, host)
             try:
                 sock.connect(sa)
-            except socket.error:
+            except socket.error as error:
                 sock.close()
                 sock = None
+                sock_err = error
                 continue
             break
         if sock is None:
-            self._socket_fail('unable to connect')
+            self._socket_fail('unable to connect; {}', sock_err)
         return sock
 
     def _connect_proxy(self, proxy_url):


### PR DESCRIPTION
**What this PR solves**

- Always propagates low level error details when a socket connection fails. This information is captured in log/exception messages and is helpful for understanding more precisely why a connection failed.

**How it is done**

- Pass any `socket.error` exception into `_socket_fail()` so that low level details about the error can be captured in log/exception messages.

**What to look out for**

-

**Screenshots (if appropriate)**

-

**Review**

- [x] Ready for review
