### PR TITLE
Use a monotonic clock for WebsocketSession's session_time

### DIFF
--- a/lomond/session.py
+++ b/lomond/session.py
@@ -13,9 +13,13 @@ import math
 import socket
 import ssl
 import threading
-import time
 
 from six.moves.urllib.parse import urlparse
+
+try:
+    from monotonic import monotonic as monotonic_time
+except:
+    from time import time as monotonic_time
 
 from .frame import Frame
 from . import errors
@@ -60,7 +64,7 @@ class WebsocketSession(object):
         return (
             0.0
             if self._start_time is None else
-            time.time() - self._start_time
+            monotonic_time() - self._start_time
         )
 
     def close(self):
@@ -321,7 +325,7 @@ class WebsocketSession(object):
         """Called when a ready event is received."""
         self._last_pong = 0.0
         self._next_ping = 0.0
-        self._start_time = time.time()
+        self._start_time = monotonic_time()
 
     def _on_event(self, event, auto_pong=True):
         """Handle logic in response to an event."""

--- a/lomond/session.py
+++ b/lomond/session.py
@@ -17,9 +17,9 @@ import threading
 from six.moves.urllib.parse import urlparse
 
 try:
-    from monotonic import monotonic as monotonic_time
+    from monotonic import monotonic as get_time
 except ImportError:
-    from time import time as monotonic_time
+    from time import time as get_time
 
 from .frame import Frame
 from . import errors
@@ -64,7 +64,7 @@ class WebsocketSession(object):
         return (
             0.0
             if self._start_time is None else
-            monotonic_time() - self._start_time
+            get_time() - self._start_time
         )
 
     def close(self):
@@ -325,7 +325,7 @@ class WebsocketSession(object):
         """Called when a ready event is received."""
         self._last_pong = 0.0
         self._next_ping = 0.0
-        self._start_time = monotonic_time()
+        self._start_time = get_time()
 
     def _on_event(self, event, auto_pong=True):
         """Handle logic in response to an event."""

--- a/lomond/session.py
+++ b/lomond/session.py
@@ -16,10 +16,7 @@ import threading
 
 from six.moves.urllib.parse import urlparse
 
-try:
-    from monotonic import monotonic as get_time
-except ImportError:
-    from time import time as get_time
+from monotonic import monotonic as monotonic_time
 
 from .frame import Frame
 from . import errors
@@ -64,7 +61,7 @@ class WebsocketSession(object):
         return (
             0.0
             if self._start_time is None else
-            get_time() - self._start_time
+            monotonic_time() - self._start_time
         )
 
     def close(self):
@@ -325,7 +322,7 @@ class WebsocketSession(object):
         """Called when a ready event is received."""
         self._last_pong = 0.0
         self._next_ping = 0.0
-        self._start_time = get_time()
+        self._start_time = monotonic_time()
 
     def _on_event(self, event, auto_pong=True):
         """Handle logic in response to an event."""

--- a/lomond/session.py
+++ b/lomond/session.py
@@ -18,7 +18,7 @@ from six.moves.urllib.parse import urlparse
 
 try:
     from monotonic import monotonic as monotonic_time
-except:
+except ImportError:
     from time import time as monotonic_time
 
 from .frame import Frame

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,7 @@ setup(
     setup_requires=['pytest-runner'],
     tests_require=['pytest'],
     install_requires=[
+        'monotonic>=1.5',
         'six>=1.10.0',
     ],
     zip_safe=True

--- a/tox.ini
+++ b/tox.ini
@@ -41,4 +41,3 @@ commands =
     coverage html -d {env:CIRCLE_ARTIFACTS:reports}/combined
     coverage report
     coveralls
-ignore_outcome = true

--- a/tox.ini
+++ b/tox.ini
@@ -40,3 +40,4 @@ commands =
     coverage html -d {env:CIRCLE_ARTIFACTS:reports}/combined
     coverage report
     coveralls
+ignore_outcome = true


### PR DESCRIPTION
**What this PR solves**

Automatically scheduled actions like ping etc. and various other timeouts rely on WebsocketSession's session_time property to determine when to execute/fire.  This property is in turn based on Python's
time.time() which does not guarantee to always return non-decreasing values though.  To quote the module documentation,

> "[...] it can return a lower value than a previous call if the system clock has been set back between the two calls."  Source: https://docs.python.org/2/library/time.html#time.time

In order to not fall victim to such quirks it is common for timeouts and stuff like that to use a so-called monotonic clock which---as their name implies---cannot go backwards due to e.g. system clock updates.  Accordingly Python 3 also introduced such a clock in release 3.3, see:

- https://docs.python.org/3/library/time.html#time.monotonic

A rationale can be found in the associated "PEP 418 -- Add monotonic time, performance counter, and process time functions":

- https://www.python.org/dev/peps/pep-0418/

**How it is done**

There is an (actively maintained, by the looks of it) compatibility library available on PyPI fittingly called monotonic which provides a suitable monotonic clock for both Python 2 and 3:

- https://pypi.org/project/monotonic/

This PR suggests to replace the time.time() calls to initialize and update the session time with calls to monotonic.monotonic() which is not affected by changes of the system time.  This of course introduces a new runtime dependency on the monotonic module.  If import monotonic fails we can simply fall back on time.time() for backwards compatibility.

**What to look out for**

Event.receive_time is still using time.time() as before.  (Note that the reference point of the values returned by a monotonic clock is generally undefined.)

**Review**

- [x] Ready for review
