### PR TITLE
Modernize CI, reliability hardening, and PyPI trusted publishing

### DIFF
--- a/.github/workflows/ci-legacy-py27.yml
+++ b/.github/workflows/ci-legacy-py27.yml
@@ -1,0 +1,54 @@
+name: CI Legacy Python
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+      - main
+
+jobs:
+  test-legacy:
+    name: ${{ matrix.name }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: py27
+            docker_tag: "2.7-slim"
+            pytest_spec: "pytest<5"
+            pytest_mock_spec: "pytest-mock<2"
+            freezegun_spec: "freezegun<1"
+          - name: py35
+            docker_tag: "3.5-slim"
+            pytest_spec: "pytest<7"
+            pytest_mock_spec: "pytest-mock<3.7"
+            freezegun_spec: "freezegun<1.3"
+          - name: py36
+            docker_tag: "3.6-slim"
+            pytest_spec: "pytest<7"
+            pytest_mock_spec: "pytest-mock<3.10"
+            freezegun_spec: "freezegun<1.3"
+          - name: py37
+            docker_tag: "3.7-slim"
+            pytest_spec: "pytest<8"
+            pytest_mock_spec: "pytest-mock<3.11"
+            freezegun_spec: "freezegun<1.4"
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run legacy compatibility suite in Docker
+      run: |
+        docker run --rm \
+          -v "$PWD":/work \
+          -w /work \
+          python:${{ matrix.docker_tag }} \
+          /bin/bash -lc "
+            pip install --upgrade pip &&
+            pip install -e . &&
+            pip install '${{ matrix.pytest_spec }}' '${{ matrix.pytest_mock_spec }}' '${{ matrix.freezegun_spec }}' &&
+            pytest -vv \
+              tests \
+              --ignore=tests/test_integration.py
+          "

--- a/.github/workflows/ci-modern.yml
+++ b/.github/workflows/ci-modern.yml
@@ -1,0 +1,35 @@
+name: CI Modern
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+      - main
+
+jobs:
+  test:
+    name: py${{ matrix.python-version }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ matrix.python-version }}
+
+      - name: Install test dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install -e .
+        python -m pip install pytest pytest-mock freezegun proxy.py
+
+      - name: Run deterministic test suite
+      run: |
+        pytest -vv \
+          --ignore=tests/test_integration.py

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -1,14 +1,24 @@
 name: Publish to PyPI
 
 on:
-  push:
-    tags:
-      - "v*"
+  release:
+    types:
+      - published
   workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: pypi-publish-${{ github.event.release.tag_name || github.ref }}
+  cancel-in-progress: false
 
 jobs:
   build:
+    if: github.repository == 'wildfoundry/dataplicity-lomond'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
 
@@ -16,6 +26,31 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: "3.12"
+
+      - name: Validate release tag format
+      run: |
+        TAG_NAME="${{ github.event.release.tag_name || github.ref_name }}"
+        case "$TAG_NAME" in
+          v*) ;;
+          *)
+            echo "Release tag '$TAG_NAME' must start with 'v'"
+            exit 1
+            ;;
+        esac
+
+      - name: Validate tag matches package version
+      run: |
+        TAG_NAME="${{ github.event.release.tag_name || github.ref_name }}"
+        TAG_VERSION="${TAG_NAME#v}"
+        PACKAGE_VERSION="$(python - <<'PY'
+from lomond._version import __version__
+print(__version__)
+PY
+)"
+        if [ "$TAG_VERSION" != "$PACKAGE_VERSION" ]; then
+          echo "Tag version '$TAG_VERSION' does not match package version '$PACKAGE_VERSION'"
+          exit 1
+        fi
 
       - name: Build distributions
       run: |
@@ -32,11 +67,13 @@ jobs:
 
   publish:
     needs: build
+    if: github.repository == 'wildfoundry/dataplicity-lomond'
     runs-on: ubuntu-latest
     environment:
       name: release
     permissions:
       id-token: write
+      contents: read
     steps:
       - name: Download distributions
       uses: actions/download-artifact@v4
@@ -46,3 +83,5 @@ jobs:
 
       - name: Publish to PyPI
       uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        attestations: true

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -1,0 +1,48 @@
+name: Publish to PyPI
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.12"
+
+      - name: Build distributions
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install build twine
+        python -m build
+        twine check dist/*
+
+      - name: Upload distributions
+      uses: actions/upload-artifact@v4
+      with:
+        name: dist-artifacts
+        path: dist/
+
+  publish:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: release
+    permissions:
+      id-token: write
+    steps:
+      - name: Download distributions
+      uses: actions/download-artifact@v4
+      with:
+        name: dist-artifacts
+        path: dist/
+
+      - name: Publish to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Deterministic local socket fixtures for websocket, HTTP, and proxy tests
 - Fuzz/property-style parser and frame roundtrip tests
 - Failure-injection coverage for session selector crashes and reconnect policy
+- Monotonic clock support for websocket session timing stability
 - Dedicated troubleshooting guide for trace-first diagnostics
 - Expanded tox env list to include modern Python versions (3.7-3.13) while
   preserving Python 2.7 support

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,31 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Added
+
+- TLS configuration controls on `WebSocket`: `ssl_verify`, `ssl_cafile`,
+  and `ssl_context`
+- Structured tracing via `WebSocket(trace=...)` for deeper runtime debugging
+- Tests for TLS wrapping behavior and tracing hooks
+- `Retry-After` support in `persist()` reconnect backoff behavior
+- Deterministic local socket fixtures for websocket, HTTP, and proxy tests
+- Fuzz/property-style parser and frame roundtrip tests
+- Failure-injection coverage for session selector crashes and reconnect policy
+- Dedicated troubleshooting guide for trace-first diagnostics
+- Expanded tox env list to include modern Python versions (3.7-3.13) while
+  preserving Python 2.7 support
+- GitHub Actions CI workflows for modern Python matrix and legacy Py2.7 lane
+- Expanded legacy GitHub Actions lane to validate Python 2.7, 3.5, 3.6, 3.7
+  in CI without requiring local Docker for developers
+
+### Fixed
+
+- Corrected `Proxy-Authorization` request header formatting
+- Corrected typo in tox `PYTHONPATH` configuration
+- Corrected broken `test_session` mock assertion (`assert_called_with`)
+
 
 ## [0.3.2] - 2018-07-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## [Unreleased]
+## [0.3.4] - 2026-07-06
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - GitHub Actions CI workflows for modern Python matrix and legacy Py2.7 lane
 - Expanded legacy GitHub Actions lane to validate Python 2.7, 3.5, 3.6, 3.7
   in CI without requiring local Docker for developers
+- Hardened PyPI Trusted Publisher workflow (release-triggered, version/tag
+  verification, environment-gated publish, OIDC attestations)
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -80,9 +80,16 @@ PyPI Trusted Publisher form values:
 Before first release, create the GitHub environment named `release` in the
 repository settings.
 
+Recommended hardening for the `release` environment:
+
+- require at least one reviewer approval before job execution
+- restrict deployment branch/tag patterns to trusted maintainers
+- keep admin bypass disabled for production releases
+
 Publishing behavior:
 
-- Push a version tag matching `v*` (for example `v0.3.3`) to trigger publish.
+- Publish workflow runs when a GitHub Release is published.
+- Release tag must start with `v` and match `lomond/_version.py`.
 - You can also run the workflow manually via `workflow_dispatch`.
 
 ## Example

--- a/README.md
+++ b/README.md
@@ -23,6 +23,68 @@ To connect to a "ws:" or "wss:" WebSocket URL, construct a `lomond.WebSocket` ob
 You will receive a ``Binary`` or ``Text`` event when the server sends you a message.
 You may _send_ a message with the ``send_binary`` or ``send_text`` methods.
 
+## TLS and Debugging
+
+`wss://` connections now verify TLS certificates by default. You can tune this
+without changing global SSL behavior:
+
+```python
+ws = WebSocket(
+    "wss://example.com/socket",
+    ssl_verify=True,                 # default
+    ssl_cafile="/etc/ssl/my-ca.pem", # optional custom CA bundle
+)
+```
+
+For deep diagnostics, pass a trace callback and Lomond will emit structured
+records for connect, handshake, send/recv, and close stages:
+
+```python
+def on_trace(record):
+    print(record)
+
+ws = WebSocket("wss://example.com/socket", trace=on_trace)
+```
+
+`lomond.persist.persist()` now also supports `Retry-After` from rejected
+upgrade responses (for example, `429 Too Many Requests`) and will use that
+delay before reconnecting when present.
+
+## Testing and CI
+
+The test suite now uses deterministic local socket fixtures for websocket,
+HTTP, and proxy scenarios (no public network dependencies required).
+
+Modern CI runs on Python 3.8 through 3.13, and a separate legacy CI lane
+runs Python 2.7, 3.5, 3.6, and 3.7 in GitHub-hosted Docker jobs.
+
+Developers do not need Docker locally to validate day-to-day changes; full
+legacy coverage is enforced in GitHub Actions.
+
+## PyPI Trusted Publisher (TPM)
+
+This repository is configured to publish to PyPI via GitHub Actions OIDC
+Trusted Publishing with no API token.
+
+Workflow file:
+
+- `.github/workflows/pypi-publish.yml`
+
+PyPI Trusted Publisher form values:
+
+- **Owner**: `wildfoundry`
+- **Repository name**: `dataplicity-lomond`
+- **Workflow name**: `pypi-publish.yml`
+- **Environment name**: `release`
+
+Before first release, create the GitHub environment named `release` in the
+repository settings.
+
+Publishing behavior:
+
+- Push a version tag matching `v*` (for example `v0.3.3`) to trigger publish.
+- You can also run the workflow manually via `workflow_dispatch`.
+
 ## Example
 
 The following is a silly example that connects to a websocket server

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -39,6 +39,7 @@ contact support@dataplicity.com.
    status.rst
    response.rst
    websocket.rst
+   troubleshooting.rst
 
 
 Indices and tables

--- a/docs/troubleshooting.rst
+++ b/docs/troubleshooting.rst
@@ -1,0 +1,61 @@
+Troubleshooting
+===============
+
+This guide focuses on diagnosing production connection issues quickly.
+
+Trace Cookbook
+--------------
+
+Enable structured tracing by passing a callback to ``WebSocket(trace=...)``.
+
+.. code-block:: python
+
+    from lomond import WebSocket
+
+    def on_trace(record):
+        print(record)
+
+    ws = WebSocket("wss://example.com/socket", trace=on_trace)
+    for event in ws.connect():
+        pass
+
+Trace records include:
+
+- ``connect_start``: connection loop settings
+- ``tls_wrapped``: TLS wrapping path and verification mode
+- ``handshake_ready`` / ``handshake_rejected``: upgrade result
+- ``socket_send`` / ``socket_recv``: transport throughput
+- ``close_requested`` / ``disconnected``: shutdown sequence
+
+Common Failure Signatures
+-------------------------
+
+``ConnectFail(reason='unable to connect; ...')``
+    DNS, routing, firewall, or proxy connectivity issue.
+
+``Rejected(..., reason='Websocket upgrade failed (code=...)')``
+    Server responded with non-``101`` HTTP status. Check endpoint path,
+    authentication, and reverse proxy upgrade configuration.
+
+``ProtocolError(..., critical=True)``
+    Invalid wire data (often invalid UTF-8 in text frames). Peer is sending
+    malformed payloads.
+
+``Disconnected(reason='socket fail; ...', graceful=False)``
+    Transport dropped unexpectedly. Inspect network stability and keepalive
+    settings.
+
+``Unresponsive``
+    No pong arrived within ``ping_timeout``. Increase timeout or inspect peer
+    responsiveness.
+
+Retry Strategy Diagnostics
+--------------------------
+
+When using ``persist()``, reconnect waits are selected in this order:
+
+1. ``Retry-After`` header from rejected handshake responses (if present and
+   ``respect_retry_after=True``)
+2. Exponential randomized backoff between ``min_wait`` and ``max_wait``
+
+Each wait is emitted as a ``BackOff`` event for observability.

--- a/lomond/_version.py
+++ b/lomond/_version.py
@@ -1,3 +1,3 @@
 from __future__ import unicode_literals
 
-__version__ = "0.3.2"
+__version__ = "0.3.4"

--- a/lomond/frame_parser.py
+++ b/lomond/frame_parser.py
@@ -20,8 +20,15 @@ log = logging.getLogger("lomond")
 class FrameParser(Parser):
     """Parses a stream of data in to HTTP headers + WS frames."""
 
-    unpack16 = struct.Struct(b"!H").unpack
-    unpack64 = struct.Struct(b"!Q").unpack
+    @classmethod
+    def unpack16(cls, data, _unpack16=struct.Struct(b'!H').unpack):
+        """Unpack 16 bits in to an integer."""
+        return _unpack16(bytes(data))[0]
+
+    @classmethod
+    def unpack64(cls, data, _unpack64=struct.Struct(b'!Q').unpack):
+        """Unpack 64 bits in to an integer."""
+        return _unpack64(bytes(data))[0]
 
     def __init__(self, parse_headers=True, validate=True):
         self.parse_headers = parse_headers
@@ -71,9 +78,9 @@ class FrameParser(Parser):
             payload_length = byte2 & 0b01111111
 
             if payload_length == 126:
-                (payload_length,) = self.unpack16((yield self.read(2)))
+                payload_length = self.unpack16((yield self.read(2)))
             elif payload_length == 127:
-                (payload_length,) = self.unpack64((yield self.read(8)))
+                payload_length = self.unpack64((yield self.read(8)))
             if payload_length > 0x7fffffffffffffff:
                 raise errors.PayloadTooLarge("payload is too large")
 

--- a/lomond/parser.py
+++ b/lomond/parser.py
@@ -18,6 +18,10 @@ class ParseEOF(ParseError):
     """End of Stream."""
 
 
+class ParseOverflow(ParseError):
+    """Extra bytes in feed after parser completed."""
+
+
 class _Awaitable(object):
     """An operation that effectively suspends the coroutine."""
     # Analogous to Python3 asyncio concept
@@ -89,6 +93,7 @@ class Parser(object):
         self._awaiting = None
         self._buffer = bytearray()  # Buffer for reads
         self._eof = False
+        self._exhausted = False
         self.reset()
 
     read = _ReadBytes
@@ -106,6 +111,9 @@ class Parser(object):
         """Reset the parser, so it may be used on a fresh stream."""
         self._gen = self.parse()
         self._awaiting = next(self._gen)
+        self._eof = False
+        self._exhausted = False
+        del self._buffer[:]
 
     def close(self):
         """Close the parser."""
@@ -127,70 +135,83 @@ class Parser(object):
             except ParseError as error:
                 self._awaiting = self._gen.throw(error)
 
+        if self._exhausted:
+            raise ParseOverflow(
+                'extra bytes in feed(); {!r}'.format(data[:100])
+            )
         if self._eof:
-            raise ParseError('end of file reached')
+            raise ParseEOF(
+                'end of file reached; feed() was previously called with empty bytes'
+            )
         if not data:
             self._eof = True
             self._gen.throw(
-                ParseError('unexpected eof of file')
+                ParseEOF('unexpected eof of file')
             )
 
         _buffer = self._buffer
         pos = 0
-        while pos < len(data):
-            # Awaiting a read of a fixed number of bytes
-            if isinstance(self._awaiting, _ReadBytes):
-                # This many bytes left to read
-                remaining = self._awaiting.remaining
-                # Bite off remaining bytes
-                chunk = data[pos:pos + remaining]
-                chunk_size = len(chunk)
-                pos += chunk_size
-                try:
-                    # Validate new data
-                    self._awaiting.validate(chunk)
-                except ParseError as error:
-                    # Raises an exception in parse()
-                    self._awaiting = self._gen.throw(error)
-                # Add to buffer
-                _buffer.extend(chunk)
-                remaining -= chunk_size
-                if remaining:
-                    # Await more bytes
-                    self._awaiting.remaining = remaining
-                else:
-                    # Send to coroutine, get new 'awaitable'
-                    self._awaiting = self._gen.send(_buffer[:])
-                    del _buffer[:]
+        try:
+            while pos < len(data):
+                # Awaiting a read of a fixed number of bytes
+                if isinstance(self._awaiting, _ReadBytes):
+                    # This many bytes left to read
+                    remaining = self._awaiting.remaining
+                    # Bite off remaining bytes
+                    chunk = data[pos:pos + remaining]
+                    chunk_size = len(chunk)
+                    pos += chunk_size
+                    try:
+                        # Validate new data
+                        self._awaiting.validate(chunk)
+                    except ParseError as error:
+                        # Raises an exception in parse()
+                        self._awaiting = self._gen.throw(error)
+                    # Add to buffer
+                    _buffer.extend(chunk)
+                    remaining -= chunk_size
+                    if remaining:
+                        # Await more bytes
+                        self._awaiting.remaining = remaining
+                    else:
+                        # Send to coroutine, get new 'awaitable'
+                        self._awaiting = self._gen.send(_buffer[:])
+                        del _buffer[:]
 
-            # Awaiting a read until a terminator
-            elif isinstance(self._awaiting, _ReadUntil):
-                # Reading to separator
-                chunk = data[pos:]
-                _buffer.extend(chunk)
-                sep = self._awaiting.sep
-                sep_index = _buffer.find(sep)
+                # Awaiting a read until a terminator
+                elif isinstance(self._awaiting, _ReadUntil):
+                    # Reading to separator
+                    chunk = data[pos:]
+                    _buffer.extend(chunk)
+                    sep = self._awaiting.sep
+                    sep_index = _buffer.find(sep)
 
-                if sep_index == -1:
-                    # Separator not found, advance position
-                    pos += len(chunk)
-                    _check_length(len(_buffer))
-                else:
-                    # Found separator
-                    # Get data prior to and including separator
-                    sep_index += len(sep)
-                    _check_length(sep_index)
-                    # Reset data, to continue parsing
-                    data = _buffer[sep_index:]
-                    pos = 0
-                    # Send bytes to coroutine, get new 'awaitable'
-                    self._awaiting = self._gen.send(_buffer[:sep_index])
-                    del _buffer[:]
+                    if sep_index == -1:
+                        # Separator not found, advance position
+                        pos += len(chunk)
+                        _check_length(len(_buffer))
+                    else:
+                        # Found separator
+                        # Get data prior to and including separator
+                        sep_index += len(sep)
+                        _check_length(sep_index)
+                        # Reset data, to continue parsing
+                        data = _buffer[sep_index:]
+                        pos = 0
+                        # Send bytes to coroutine, get new 'awaitable'
+                        self._awaiting = self._gen.send(_buffer[:sep_index])
+                        del _buffer[:]
 
-            # Yield any non-awaitables...
-            while not isinstance(self._awaiting, _Awaitable):
-                yield self._awaiting
-                self._awaiting = next(self._gen)
+                # Yield any non-awaitables...
+                while not isinstance(self._awaiting, _Awaitable):
+                    yield self._awaiting
+                    self._awaiting = next(self._gen)
+        except StopIteration:
+            self._exhausted = True
+            if pos < len(data):
+                raise ParseOverflow(
+                    'extra bytes in feed(); {!r}'.format(data[pos:][:100])
+                )
 
     def parse(self):
         """

--- a/lomond/persist.py
+++ b/lomond/persist.py
@@ -5,16 +5,38 @@ Maintains a persistent websocket connection.
 
 from __future__ import unicode_literals
 
+from email.utils import mktime_tz, parsedate_tz
 from random import random
 import threading
+import time
 
 from . import events
+
+
+def _parse_retry_after(value):
+    """Parse a Retry-After header value to seconds."""
+    if value is None:
+        return None
+    value = value.strip()
+    if not value:
+        return None
+    try:
+        retry_after = float(value)
+    except ValueError:
+        parsed = parsedate_tz(value)
+        if parsed is None:
+            return None
+        retry_after = mktime_tz(parsed) - time.time()
+    if retry_after < 0:
+        return 0.0
+    return retry_after
 
 
 def persist(websocket, poll=5,
             min_wait=5, max_wait=30,
             ping_rate=30, ping_timeout=None,
-            exit_event=None):
+            exit_event=None,
+            respect_retry_after=True):
     """Run a websocket, with a retry mechanism and exponential back-off.
 
     :param websocket: A :class:`~lomond.websocket.Websocket` instance.
@@ -32,6 +54,8 @@ def persist(websocket, poll=5,
     :param exit_event: A threading event object, which can be used to
         exit the persist loop if it is set. Set to `None` to use an
         internal event object.
+    :param bool respect_retry_after: If ``True`` (default), respect
+        ``Retry-After`` headers on rejected upgrade responses.
 
     """
     if exit_event is None:
@@ -40,13 +64,21 @@ def persist(websocket, poll=5,
     random_wait = max_wait - min_wait
     while True:
         retries += 1
+        retry_after = None
         for event in websocket.connect(
                 poll=poll, ping_rate=ping_rate, ping_timeout=ping_timeout):
             if event.name == 'ready':
                 # The server accepted the WS upgrade.
                 retries = 0
+            elif respect_retry_after and event.name == 'rejected':
+                response = getattr(event, 'response', None)
+                if response is not None:
+                    retry_after = _parse_retry_after(response.get('retry-after'))
             yield event
-        wait_for = min_wait + random() * min(random_wait, 2**retries)
+        if retry_after is None:
+            wait_for = min_wait + random() * min(random_wait, 2**retries)
+        else:
+            wait_for = retry_after
         yield events.BackOff(wait_for)
         if exit_event.wait(wait_for):
             break

--- a/lomond/proxy.py
+++ b/lomond/proxy.py
@@ -34,7 +34,7 @@ def build_request(host, port, proxy_username=None, proxy_password=None):
         ).encode('utf-8')
         b64_credentials = base64.standard_b64encode(credentials)
         headers.append(
-            (b'Proxy-Authorization:', b'Basic ' + b64_credentials)
+            (b'Proxy-Authorization', b'Basic ' + b64_credentials)
         )
 
     for header, value in headers:
@@ -46,7 +46,7 @@ def build_request(host, port, proxy_username=None, proxy_password=None):
 
 
 class ProxyParser(Parser):
-    """Parser for communication with a SOCKS proxy."""
+    """Parser for communication with an HTTP CONNECT proxy."""
 
     def parse(self):
         try:

--- a/lomond/session.py
+++ b/lomond/session.py
@@ -89,6 +89,7 @@ class WebsocketSession(object):
                 raise errors.WebSocketClosing('data not sent')
             try:
                 self._sock.sendall(data)
+                self.websocket._emit_trace('socket_send', length=len(data))
             except socket.error as error:
                 log.debug('WebSocket send error; %s', error)
                 raise errors.TransportFail(
@@ -207,20 +208,56 @@ class WebsocketSession(object):
 
     def _wrap_socket(self, sock, host):
         """Wrap the socket with an SSL proxy."""
-        # sniff SNI support (added Python 2.7.9)
-        if HAS_SNI:
-            _protocol = getattr(
-                ssl,
-                'PROTOCOL_TLS',  # Supported since 2.7.13
-                ssl.PROTOCOL_SSLv23   # Supported since 2.7.9
-            )
-            ssl_context = ssl.SSLContext(_protocol)
-            ssl_sock = ssl_context.wrap_socket(
-                sock, server_hostname=host
-            )
+        verify = self.websocket.ssl_verify
+        cafile = self.websocket.ssl_cafile
+        ssl_context = self.websocket.ssl_context
+
+        if ssl_context is None:
+            if verify and hasattr(ssl, 'create_default_context'):
+                kwargs = {}
+                if cafile is not None:
+                    kwargs['cafile'] = cafile
+                ssl_context = ssl.create_default_context(**kwargs)
+            elif not verify and hasattr(ssl, '_create_unverified_context'):
+                ssl_context = ssl._create_unverified_context()
+            elif hasattr(ssl, 'SSLContext'):
+                _protocol = getattr(
+                    ssl,
+                    'PROTOCOL_TLS',
+                    ssl.PROTOCOL_SSLv23
+                )
+                ssl_context = ssl.SSLContext(_protocol)
+                if verify:
+                    if hasattr(ssl_context, 'verify_mode'):
+                        ssl_context.verify_mode = ssl.CERT_REQUIRED
+                    if cafile is not None and hasattr(ssl_context, 'load_verify_locations'):
+                        ssl_context.load_verify_locations(cafile)
+                    elif hasattr(ssl_context, 'set_default_verify_paths'):
+                        ssl_context.set_default_verify_paths()
+                else:
+                    if hasattr(ssl_context, 'check_hostname'):
+                        ssl_context.check_hostname = False
+                    if hasattr(ssl_context, 'verify_mode'):
+                        ssl_context.verify_mode = ssl.CERT_NONE
+
+        if ssl_context is not None:
+            if HAS_SNI:
+                ssl_sock = ssl_context.wrap_socket(
+                    sock, server_hostname=host
+                )
+            else:
+                ssl_sock = ssl_context.wrap_socket(sock)
         else:
-            # Fallback for no SNI
-            ssl_sock = ssl.wrap_socket(sock)
+            wrap_kwargs = {'cert_reqs': ssl.CERT_REQUIRED if verify else ssl.CERT_NONE}
+            if cafile is not None:
+                wrap_kwargs['ca_certs'] = cafile
+            ssl_sock = ssl.wrap_socket(sock, **wrap_kwargs)
+        self.websocket._emit_trace(
+            'tls_wrapped',
+            verify=verify,
+            has_context=ssl_context is not None,
+            cafile=bool(cafile)
+        )
         log.debug('wrapped socket %r', ssl_sock)
         return ssl_sock
 
@@ -296,6 +333,7 @@ class WebsocketSession(object):
             return bytearray(b'')
         try:
             _recv_count = self._sock.recv_into(self._buffer, count)
+            self.websocket._emit_trace('socket_recv', length=_recv_count)
             return memoryview(self._buffer)[:_recv_count]
         except socket.error as error:
             log.debug('error in _recv', exc_info=True)

--- a/lomond/session.py
+++ b/lomond/session.py
@@ -249,21 +249,26 @@ class WebsocketSession(object):
                         ssl_context.verify_mode = ssl.CERT_NONE
 
         if ssl_context is not None:
-            if hasattr(ssl, 'TLSVersion') and hasattr(ssl_context, 'minimum_version'):
+            try:
                 ssl_context.minimum_version = ssl.TLSVersion.TLSv1_2
-            else:
-                if hasattr(ssl, 'OP_NO_TLSv1') and hasattr(ssl_context, 'options'):
-                    ssl_context.options |= ssl.OP_NO_TLSv1
-                if hasattr(ssl, 'OP_NO_TLSv1_1') and hasattr(ssl_context, 'options'):
-                    ssl_context.options |= ssl.OP_NO_TLSv1_1
+            except Exception:
+                pass
+            try:
+                ssl_context.options |= ssl.OP_NO_TLSv1
+            except Exception:
+                pass
+            try:
+                ssl_context.options |= ssl.OP_NO_TLSv1_1
+            except Exception:
+                pass
 
         if ssl_context is not None:
             if HAS_SNI:
-                ssl_sock = ssl_context.wrap_socket(  # lgtm[py/insecure-default-protocol]
+                ssl_sock = ssl_context.wrap_socket(
                     sock, server_hostname=host
                 )
             else:
-                ssl_sock = ssl_context.wrap_socket(sock)  # lgtm[py/insecure-default-protocol]
+                ssl_sock = ssl_context.wrap_socket(sock)
         else:
             ssl_version = _select_ssl_protocol()
             cert_reqs = ssl.CERT_REQUIRED if verify else ssl.CERT_NONE

--- a/lomond/session.py
+++ b/lomond/session.py
@@ -212,6 +212,18 @@ class WebsocketSession(object):
         cafile = self.websocket.ssl_cafile
         ssl_context = self.websocket.ssl_context
 
+        def _harden_context(context):
+            """Prefer TLS 1.2+ where runtime supports minimum_version."""
+            if context is None:
+                return
+            if hasattr(ssl, 'TLSVersion') and hasattr(context, 'minimum_version'):
+                context.minimum_version = ssl.TLSVersion.TLSv1_2
+            else:
+                if hasattr(ssl, 'OP_NO_TLSv1') and hasattr(context, 'options'):
+                    context.options |= ssl.OP_NO_TLSv1
+                if hasattr(ssl, 'OP_NO_TLSv1_1') and hasattr(context, 'options'):
+                    context.options |= ssl.OP_NO_TLSv1_1
+
         if ssl_context is None:
             if verify and hasattr(ssl, 'create_default_context'):
                 kwargs = {}
@@ -239,6 +251,7 @@ class WebsocketSession(object):
                         ssl_context.check_hostname = False
                     if hasattr(ssl_context, 'verify_mode'):
                         ssl_context.verify_mode = ssl.CERT_NONE
+        _harden_context(ssl_context)
 
         if ssl_context is not None:
             if HAS_SNI:
@@ -248,7 +261,14 @@ class WebsocketSession(object):
             else:
                 ssl_sock = ssl_context.wrap_socket(sock)
         else:
-            wrap_kwargs = {'cert_reqs': ssl.CERT_REQUIRED if verify else ssl.CERT_NONE}
+            wrap_kwargs = {
+                'cert_reqs': ssl.CERT_REQUIRED if verify else ssl.CERT_NONE,
+                'ssl_version': getattr(
+                    ssl,
+                    'PROTOCOL_TLSv1_2',
+                    getattr(ssl, 'PROTOCOL_TLS', ssl.PROTOCOL_SSLv23)
+                )
+            }
             if cafile is not None:
                 wrap_kwargs['ca_certs'] = cafile
             ssl_sock = ssl.wrap_socket(sock, **wrap_kwargs)

--- a/lomond/session.py
+++ b/lomond/session.py
@@ -259,11 +259,11 @@ class WebsocketSession(object):
 
         if ssl_context is not None:
             if HAS_SNI:
-                ssl_sock = ssl_context.wrap_socket(
+                ssl_sock = ssl_context.wrap_socket(  # lgtm[py/insecure-default-protocol]
                     sock, server_hostname=host
                 )
             else:
-                ssl_sock = ssl_context.wrap_socket(sock)
+                ssl_sock = ssl_context.wrap_socket(sock)  # lgtm[py/insecure-default-protocol]
         else:
             ssl_version = _select_ssl_protocol()
             cert_reqs = ssl.CERT_REQUIRED if verify else ssl.CERT_NONE

--- a/lomond/session.py
+++ b/lomond/session.py
@@ -212,17 +212,14 @@ class WebsocketSession(object):
         cafile = self.websocket.ssl_cafile
         ssl_context = self.websocket.ssl_context
 
-        def _harden_context(context):
-            """Prefer TLS 1.2+ where runtime supports minimum_version."""
-            if context is None:
-                return
-            if hasattr(ssl, 'TLSVersion') and hasattr(context, 'minimum_version'):
-                context.minimum_version = ssl.TLSVersion.TLSv1_2
-            else:
-                if hasattr(ssl, 'OP_NO_TLSv1') and hasattr(context, 'options'):
-                    context.options |= ssl.OP_NO_TLSv1
-                if hasattr(ssl, 'OP_NO_TLSv1_1') and hasattr(context, 'options'):
-                    context.options |= ssl.OP_NO_TLSv1_1
+        def _select_ssl_protocol():
+            if hasattr(ssl, 'PROTOCOL_TLS_CLIENT'):
+                return ssl.PROTOCOL_TLS_CLIENT
+            if hasattr(ssl, 'PROTOCOL_TLSv1_2'):
+                return ssl.PROTOCOL_TLSv1_2
+            if hasattr(ssl, 'PROTOCOL_TLS'):
+                return ssl.PROTOCOL_TLS
+            return ssl.PROTOCOL_SSLv23
 
         if ssl_context is None:
             if verify and hasattr(ssl, 'create_default_context'):
@@ -233,17 +230,16 @@ class WebsocketSession(object):
             elif not verify and hasattr(ssl, '_create_unverified_context'):
                 ssl_context = ssl._create_unverified_context()
             elif hasattr(ssl, 'SSLContext'):
-                _protocol = getattr(
-                    ssl,
-                    'PROTOCOL_TLS',
-                    ssl.PROTOCOL_SSLv23
-                )
-                ssl_context = ssl.SSLContext(_protocol)
+                ssl_context = ssl.SSLContext(_select_ssl_protocol())
                 if verify:
+                    if hasattr(ssl_context, 'check_hostname'):
+                        ssl_context.check_hostname = True
                     if hasattr(ssl_context, 'verify_mode'):
                         ssl_context.verify_mode = ssl.CERT_REQUIRED
                     if cafile is not None and hasattr(ssl_context, 'load_verify_locations'):
                         ssl_context.load_verify_locations(cafile)
+                    elif hasattr(ssl_context, 'load_default_certs'):
+                        ssl_context.load_default_certs()
                     elif hasattr(ssl_context, 'set_default_verify_paths'):
                         ssl_context.set_default_verify_paths()
                 else:
@@ -251,7 +247,15 @@ class WebsocketSession(object):
                         ssl_context.check_hostname = False
                     if hasattr(ssl_context, 'verify_mode'):
                         ssl_context.verify_mode = ssl.CERT_NONE
-        _harden_context(ssl_context)
+
+        if ssl_context is not None:
+            if hasattr(ssl, 'TLSVersion') and hasattr(ssl_context, 'minimum_version'):
+                ssl_context.minimum_version = ssl.TLSVersion.TLSv1_2
+            else:
+                if hasattr(ssl, 'OP_NO_TLSv1') and hasattr(ssl_context, 'options'):
+                    ssl_context.options |= ssl.OP_NO_TLSv1
+                if hasattr(ssl, 'OP_NO_TLSv1_1') and hasattr(ssl_context, 'options'):
+                    ssl_context.options |= ssl.OP_NO_TLSv1_1
 
         if ssl_context is not None:
             if HAS_SNI:
@@ -261,17 +265,19 @@ class WebsocketSession(object):
             else:
                 ssl_sock = ssl_context.wrap_socket(sock)
         else:
-            wrap_kwargs = {
-                'cert_reqs': ssl.CERT_REQUIRED if verify else ssl.CERT_NONE,
-                'ssl_version': getattr(
-                    ssl,
-                    'PROTOCOL_TLSv1_2',
-                    getattr(ssl, 'PROTOCOL_TLS', ssl.PROTOCOL_SSLv23)
+            ssl_version = _select_ssl_protocol()
+            cert_reqs = ssl.CERT_REQUIRED if verify else ssl.CERT_NONE
+            if cafile is None:
+                ssl_sock = ssl.wrap_socket(
+                    sock, cert_reqs=cert_reqs, ssl_version=ssl_version
                 )
-            }
-            if cafile is not None:
-                wrap_kwargs['ca_certs'] = cafile
-            ssl_sock = ssl.wrap_socket(sock, **wrap_kwargs)
+            else:
+                ssl_sock = ssl.wrap_socket(
+                    sock,
+                    cert_reqs=cert_reqs,
+                    ca_certs=cafile,
+                    ssl_version=ssl_version
+                )
         self.websocket._emit_trace(
             'tls_wrapped',
             verify=verify,

--- a/lomond/session.py
+++ b/lomond/session.py
@@ -27,6 +27,11 @@ from . import selectors
 HAS_SNI = hasattr(ssl, 'SSLContext') and getattr(ssl, 'HAS_SNI', False)
 log = logging.getLogger('lomond')
 
+try:
+    from monotonic import monotonic as monotonic_time
+except Exception:  # pragma: no cover
+    monotonic_time = getattr(time, 'monotonic', time.time)
+
 
 class _SocketFail(Exception):
     """Used internally to respond to socket fails."""
@@ -63,7 +68,7 @@ class WebsocketSession(object):
         return (
             0.0
             if self._start_time is None else
-            time.time() - self._start_time
+            monotonic_time() - self._start_time
         )
 
     def close(self):
@@ -399,7 +404,7 @@ class WebsocketSession(object):
         """Called when a ready event is received."""
         self._last_pong = 0.0
         self._next_ping = 0.0
-        self._start_time = time.time()
+        self._start_time = monotonic_time()
 
     def _on_event(self, event, auto_pong=True):
         """Handle logic in response to an event."""

--- a/lomond/stream.py
+++ b/lomond/stream.py
@@ -71,6 +71,13 @@ class WebsocketStream(object):
                 raise errors.CriticalProtocolError(
                     text_type(error)
                 )
+            except errors.WebSocketError:
+                raise
+            except Exception as error:
+                log.exception('unknown error in websocket stream')
+                raise errors.CriticalProtocolError(
+                    'unknown error; {}'.format(error)
+                )
             log.debug(" SRV -> CLI : %r", frame)
             if frame.is_control:
                 # Control messages are never fragmented

--- a/lomond/websocket.py
+++ b/lomond/websocket.py
@@ -44,6 +44,12 @@ class WebSocket(object):
     :param str agent: A user agent string to be sent in the header. The
         default uses the value ``USER_AGENT`` defined in
         :mod:`lomond.constants`.
+    :param bool ssl_verify: Verify TLS certificates for ``wss://``
+        connections (default ``True``).
+    :param str ssl_cafile: Optional path to a CA bundle file used for
+        TLS verification.
+    :param ssl.SSLContext ssl_context: Optional custom SSL context.
+    :param trace: Optional callable for structured debug trace records.
 
     """
 
@@ -63,12 +69,20 @@ class WebSocket(object):
                  proxies=None,
                  protocols=None,
                  agent=None,
-                 compress=False):
+                 compress=False,
+                 ssl_verify=True,
+                 ssl_cafile=None,
+                 ssl_context=None,
+                 trace=None):
         self.url = url
         self.proxies = self._detect_proxies() if proxies is None else proxies
         self.protocols = protocols or []
         self.agent = agent or constants.USER_AGENT
         self.compress = compress
+        self.ssl_verify = ssl_verify
+        self.ssl_cafile = ssl_cafile
+        self.ssl_context = ssl_context
+        self.trace = trace
 
         self._headers = []
         _url = urlparse(url)
@@ -97,6 +111,17 @@ class WebSocket(object):
 
     def __repr__(self):
         return "WebSocket('{}')".format(self.url)
+
+    def _emit_trace(self, stage, **fields):
+        """Emit an optional trace record for in-depth debugging."""
+        if not self.trace:
+            return
+        record = {'stage': stage, 'url': self.url}
+        record.update(fields)
+        if callable(self.trace):
+            self.trace(record)
+        else:
+            log.debug('TRACE %r', record)
 
     @property
     def is_secure(self):
@@ -207,6 +232,14 @@ class WebSocket(object):
         """
         self.reset()
         self.state.session = session = session_class(self)
+        self._emit_trace(
+            'connect_start',
+            poll=poll,
+            ping_rate=ping_rate,
+            ping_timeout=ping_timeout,
+            auto_pong=auto_pong,
+            close_timeout=close_timeout
+        )
         run_generator = session.run(
             poll=poll,
             ping_rate=ping_rate,
@@ -248,6 +281,7 @@ class WebSocket(object):
                 self._send_close(code, reason)
                 self.state.closing = True
                 self.state.sent_close_time = self.session.session_time
+                self._emit_trace('close_requested', code=code, reason=reason)
 
     def _on_close(self, message):
         """Close logic generator."""
@@ -278,6 +312,7 @@ class WebSocket(object):
             self.state.session.close()
         self.state.closing = False
         self.state.closed = True
+        self._emit_trace('disconnected')
 
     def feed(self, data):
         """Feed with data from the socket, and yield any events.
@@ -298,21 +333,40 @@ class WebSocket(object):
                         protocol, extensions = self.on_response(response)
                     except errors.HandshakeError as error:
                         self.on_disconnect()
+                        self._emit_trace(
+                            'handshake_rejected',
+                            reason=six.text_type(error),
+                            status_code=response.status_code
+                        )
                         yield events.Rejected(response, six.text_type(error))
                         break
                     else:
+                        self._emit_trace(
+                            'handshake_ready',
+                            protocol=protocol,
+                            extensions=sorted(extensions)
+                        )
                         yield events.Ready(response, protocol, extensions)
                 else:
                     if message.is_close:
                         for event in self._on_close(message):
+                            self._emit_trace(
+                                'message_close',
+                                code=event.code,
+                                reason=event.reason
+                            )
                             yield event
                     elif message.is_ping:
+                        self._emit_trace('message_ping', length=len(message.data))
                         yield events.Ping(message.data)
                     elif message.is_pong:
+                        self._emit_trace('message_pong', length=len(message.data))
                         yield events.Pong(message.data)
                     elif message.is_binary:
+                        self._emit_trace('message_binary', length=len(message.data))
                         yield events.Binary(message.data)
                     elif message.is_text:
+                        self._emit_trace('message_text', length=len(message.text))
                         yield events.Text(message.text)
                 if self.is_closed:
                     break
@@ -440,6 +494,7 @@ class WebSocket(object):
             raise TypeError('data argument must be bytes')
         if len(data) > 125:
             raise ValueError('ping data should be <= 125 bytes')
+        self._emit_trace('send_ping', length=len(data))
         self.session.send(Opcode.PING, data)
 
     def send_pong(self, data):
@@ -459,6 +514,7 @@ class WebSocket(object):
             raise TypeError('data argument must be bytes')
         if len(data) > 125:
             raise ValueError('pong data should be <= 125 bytes')
+        self._emit_trace('send_pong', length=len(data))
         self.session.send(Opcode.PONG, data)
 
     def send_binary(self, data, compress=True):
@@ -472,6 +528,7 @@ class WebSocket(object):
         """
         if not isinstance(data, bytes):
             raise TypeError('data argument must be bytes')
+        self._emit_trace('send_binary', length=len(data), compressed=bool(compress))
         if compress and self.state.compression:
             _payload = self.state.compression.compress(data)
             self.session.send_compressed(Opcode.BINARY, _payload)
@@ -516,6 +573,7 @@ class WebSocket(object):
         if not isinstance(text, six.text_type):
             raise TypeError('text argument must not be bytes')
         payload = text.encode('utf-8')
+        self._emit_trace('send_text', length=len(payload), compressed=bool(compress))
         if compress and self.state.compression:
             _payload = self.state.compression.compress(payload)
             self.session.send_compressed(Opcode.TEXT, _payload)

--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,7 @@ setup(
     setup_requires=['pytest-runner'],
     tests_require=['pytest'],
     install_requires=[
+        "monotonic>=1.5; python_version < '3.3'",
         'six>=1.10.0',
     ],
     zip_safe=True

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,13 @@ classifiers = [
     'Programming Language :: Python :: 3.4',
     'Programming Language :: Python :: 3.5',
     'Programming Language :: Python :: 3.6',
+    'Programming Language :: Python :: 3.7',
+    'Programming Language :: Python :: 3.8',
+    'Programming Language :: Python :: 3.9',
+    'Programming Language :: Python :: 3.10',
+    'Programming Language :: Python :: 3.11',
+    'Programming Language :: Python :: 3.12',
+    'Programming Language :: Python :: 3.13',
     'Topic :: Internet'
 ]
 

--- a/tests/socket_fixtures.py
+++ b/tests/socket_fixtures.py
@@ -1,0 +1,298 @@
+from __future__ import unicode_literals
+
+from base64 import b64encode
+from hashlib import sha1
+import socket
+import select
+import threading
+
+from lomond import constants
+from lomond.frame import Frame
+from lomond.opcode import Opcode
+
+
+def get_free_port():
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock.bind(('127.0.0.1', 0))
+    port = sock.getsockname()[1]
+    sock.close()
+    return port
+
+
+def _recv_until(sock, separator):
+    data = b''
+    while separator not in data:
+        chunk = sock.recv(4096)
+        if not chunk:
+            break
+        data += chunk
+    return data
+
+
+def _recv_exact(sock, size):
+    data = b''
+    while len(data) < size:
+        chunk = sock.recv(size - len(data))
+        if not chunk:
+            return None
+        data += chunk
+    return data
+
+
+def _bytes_to_int(value):
+    if not value:
+        return 0
+    result = 0
+    for byte in bytearray(value):
+        result = (result << 8) | byte
+    return result
+
+
+def _read_frame(sock):
+    header = _recv_exact(sock, 2)
+    if not header:
+        return None
+    byte1 = ord(header[:1]) if not isinstance(header[0], int) else header[0]
+    byte2 = ord(header[1:2]) if not isinstance(header[1], int) else header[1]
+    opcode = byte1 & 0x0F
+    masked = bool(byte2 & 0x80)
+    length = byte2 & 0x7F
+    if length == 126:
+        _length = _recv_exact(sock, 2)
+        if _length is None:
+            return None
+        length = _bytes_to_int(_length)
+    elif length == 127:
+        _length = _recv_exact(sock, 8)
+        if _length is None:
+            return None
+        length = _bytes_to_int(_length)
+    if masked:
+        if _recv_exact(sock, 4) is None:
+            return None
+    if length and _recv_exact(sock, length) is None:
+        return None
+    return opcode
+
+
+def _handshake_response(request_headers):
+    key = None
+    for line in request_headers.split(b'\r\n'):
+        if line.lower().startswith(b'sec-websocket-key:'):
+            key = line.split(b':', 1)[1].strip()
+            break
+    if key is None:
+        return None
+    accept = b64encode(sha1(key + constants.WS_KEY).digest())
+    response = (
+        b'HTTP/1.1 101 Switching Protocols\r\n'
+        b'Upgrade: websocket\r\n'
+        b'Connection: Upgrade\r\n'
+        b'Sec-WebSocket-Accept: ' + accept + b'\r\n'
+        b'\r\n'
+    )
+    return response
+
+
+class LocalWebSocketServer(object):
+    def __init__(self, port, messages=None, close_after_messages=False):
+        self.port = port
+        self.messages = messages or []
+        self.close_after_messages = close_after_messages
+        self._server = None
+        self._thread = None
+        self._stopped = threading.Event()
+
+    def start(self):
+        self._server = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        self._server.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        self._server.bind(('127.0.0.1', self.port))
+        self._server.listen(5)
+        self._server.settimeout(0.2)
+        self._thread = threading.Thread(target=self._run)
+        self._thread.daemon = True
+        self._thread.start()
+
+    def stop(self):
+        self._stopped.set()
+        if self._server is not None:
+            try:
+                self._server.close()
+            except Exception:
+                pass
+        if self._thread is not None:
+            self._thread.join(1.0)
+
+    def _run(self):
+        while not self._stopped.is_set():
+            try:
+                conn, _addr = self._server.accept()
+            except socket.timeout:
+                continue
+            except Exception:
+                return
+            self._handle_connection(conn)
+
+    def _handle_connection(self, conn):
+        try:
+            request_headers = _recv_until(conn, b'\r\n\r\n')
+            response = _handshake_response(request_headers)
+            if response is None:
+                return
+            conn.sendall(response)
+
+            for message_type, payload in self.messages:
+                if message_type == 'text':
+                    frame = Frame(Opcode.TEXT, payload.encode('utf-8'), mask=False)
+                else:
+                    frame = Frame(Opcode.BINARY, payload, mask=False)
+                conn.sendall(frame.to_bytes())
+
+            if self.close_after_messages:
+                conn.sendall(Frame(Opcode.CLOSE, b'', mask=False).to_bytes())
+                return
+
+            while True:
+                opcode = _read_frame(conn)
+                if opcode is None:
+                    return
+                if opcode == Opcode.CLOSE:
+                    conn.sendall(Frame(Opcode.CLOSE, b'', mask=False).to_bytes())
+                    return
+        finally:
+            try:
+                conn.close()
+            except Exception:
+                pass
+
+
+class LocalHTTPServer(object):
+    def __init__(self, port):
+        self.port = port
+        self._server = None
+        self._thread = None
+        self._stopped = threading.Event()
+
+    def start(self):
+        self._server = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        self._server.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        self._server.bind(('127.0.0.1', self.port))
+        self._server.listen(5)
+        self._server.settimeout(0.2)
+        self._thread = threading.Thread(target=self._run)
+        self._thread.daemon = True
+        self._thread.start()
+
+    def stop(self):
+        self._stopped.set()
+        if self._server is not None:
+            try:
+                self._server.close()
+            except Exception:
+                pass
+        if self._thread is not None:
+            self._thread.join(1.0)
+
+    def _run(self):
+        while not self._stopped.is_set():
+            try:
+                conn, _addr = self._server.accept()
+            except socket.timeout:
+                continue
+            except Exception:
+                return
+            try:
+                _recv_until(conn, b'\r\n\r\n')
+                conn.sendall(
+                    b'HTTP/1.1 200 OK\r\n'
+                    b'Content-Type: text/plain\r\n'
+                    b'Content-Length: 17\r\n'
+                    b'\r\n'
+                    b'not a websocket'
+                )
+            finally:
+                conn.close()
+
+
+class LocalConnectProxy(object):
+    def __init__(self, port):
+        self.port = port
+        self._server = None
+        self._thread = None
+        self._stopped = threading.Event()
+
+    def start(self):
+        self._server = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        self._server.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        self._server.bind(('127.0.0.1', self.port))
+        self._server.listen(5)
+        self._server.settimeout(0.2)
+        self._thread = threading.Thread(target=self._run)
+        self._thread.daemon = True
+        self._thread.start()
+
+    def stop(self):
+        self._stopped.set()
+        if self._server is not None:
+            try:
+                self._server.close()
+            except Exception:
+                pass
+        if self._thread is not None:
+            self._thread.join(1.0)
+
+    def _run(self):
+        while not self._stopped.is_set():
+            try:
+                conn, _addr = self._server.accept()
+            except socket.timeout:
+                continue
+            except Exception:
+                return
+            thread = threading.Thread(target=self._handle_connection, args=(conn,))
+            thread.daemon = True
+            thread.start()
+
+    def _handle_connection(self, client):
+        upstream = None
+        try:
+            request = _recv_until(client, b'\r\n\r\n')
+            first_line = request.split(b'\r\n', 1)[0]
+            parts = first_line.split()
+            if len(parts) < 2 or parts[0] != b'CONNECT':
+                client.sendall(b'HTTP/1.1 400 Bad Request\r\n\r\n')
+                return
+            host_port = parts[1].decode('ascii', 'replace')
+            host, port = host_port.rsplit(':', 1)
+            upstream = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            upstream.connect((host, int(port)))
+            client.sendall(
+                b'HTTP/1.1 200 Connection established\r\n'
+                b'Connection: keep-alive\r\n'
+                b'\r\n'
+            )
+            sockets = [client, upstream]
+            while True:
+                readable, _, _ = select.select(sockets, [], [], 0.2)
+                if not readable:
+                    if self._stopped.is_set():
+                        return
+                    continue
+                for source in readable:
+                    data = source.recv(4096)
+                    if not data:
+                        return
+                    if source is client:
+                        upstream.sendall(data)
+                    else:
+                        client.sendall(data)
+        finally:
+            try:
+                client.close()
+            except Exception:
+                pass
+            if upstream is not None:
+                try:
+                    upstream.close()
+                except Exception:
+                    pass

--- a/tests/test_fuzzing.py
+++ b/tests/test_fuzzing.py
@@ -1,0 +1,54 @@
+from __future__ import unicode_literals
+
+import random
+
+from lomond.frame import Frame
+from lomond.frame_parser import FrameParser
+from lomond.opcode import Opcode
+from lomond.parser import Parser
+
+
+def _random_payload(rng, size):
+    return bytes(bytearray(rng.randrange(0, 256) for _ in range(size)))
+
+
+def test_frame_parser_random_roundtrip():
+    rng = random.Random(1337)
+    parser = FrameParser(parse_headers=False, validate=False)
+    for _ in range(200):
+        opcode = rng.choice([Opcode.TEXT, Opcode.BINARY, Opcode.PING, Opcode.PONG])
+        size = rng.randrange(0, 200)
+        if opcode in (Opcode.PING, Opcode.PONG):
+            size = min(size, 125)
+        if opcode == Opcode.TEXT:
+            payload = bytes(bytearray(rng.randrange(32, 126) for _ in range(size)))
+        else:
+            payload = _random_payload(rng, size)
+        frame_bytes = Frame(opcode, payload=bytearray(payload), mask=False).to_bytes()
+        parsed = list(parser.feed(frame_bytes))
+        frame = parsed[0]
+        assert frame.opcode == opcode
+        assert bytes(frame.payload) == payload
+
+
+def test_parser_random_chunk_boundaries():
+    class SplitParser(Parser):
+        def parse(self):
+            while True:
+                first = yield self.read(3)
+                second = yield self.read_until(b'\n')
+                third = yield self.read(2)
+                yield first + second + third
+
+    rng = random.Random(7)
+    source = b'ABChello world\nZZ'
+    parser = SplitParser()
+    pos = 0
+    result = []
+    while pos < len(source):
+        step = rng.randrange(1, 5)
+        chunk = source[pos:pos + step]
+        pos += step
+        for value in parser.feed(chunk):
+            result.append(value)
+    assert result == [source]

--- a/tests/test_live.py
+++ b/tests/test_live.py
@@ -1,70 +1,64 @@
 import lomond
+import pytest
+
 from lomond import events
 from lomond.session import WebsocketSession
 from lomond import selectors
+from socket_fixtures import get_free_port, LocalWebSocketServer, LocalHTTPServer
 
 
-def test_echo():
-    """Test against public echo server."""
-    # TODO: host our own echo server
-    ws = lomond.WebSocket('wss://echo.websocket.org')
-    events = []
+@pytest.fixture(scope='module')
+def local_ws_url():
+    port = get_free_port()
+    server = LocalWebSocketServer(
+        port,
+        messages=[('text', u'foo'), ('binary', b'bar')],
+        close_after_messages=True
+    )
+    server.start()
+    yield 'ws://127.0.0.1:{}/echo'.format(port)
+    server.stop()
+
+
+@pytest.fixture(scope='module')
+def local_idle_ws_url():
+    port = get_free_port()
+    server = LocalWebSocketServer(port, messages=[], close_after_messages=False)
+    server.start()
+    yield 'ws://127.0.0.1:{}/echo'.format(port)
+    server.stop()
+
+
+@pytest.fixture(scope='module')
+def local_http_url():
+    port = get_free_port()
+    server = LocalHTTPServer(port)
+    server.start()
+    yield 'http://127.0.0.1:{}/'.format(port)
+    server.stop()
+
+
+def test_echo(local_ws_url):
+    ws = lomond.WebSocket(local_ws_url)
+    _events = []
     for event in ws.connect(poll=60, ping_rate=0, auto_pong=False):
-        events.append(event)
-        if event.name == 'ready':
-            ws.send_text(u'foo')
-            ws.send_binary(b'bar')
-            ws.close()
-
-    assert len(events) == 8
-    assert events[0].name == 'connecting'
-    assert events[1].name == 'connected'
-    assert events[2].name == 'ready'
-    assert events[3].name == 'poll'
-    assert events[4].name == 'text'
-    assert events[4].text == u'foo'
-    assert events[5].name == 'binary'
-    assert events[5].data == b'bar'
-    assert events[6].name == 'closed'
-    assert events[7].name == 'disconnected'
-    assert events[7].graceful
+        _events.append(event)
+    assert len(_events) == 8
+    assert _events[0].name == 'connecting'
+    assert _events[1].name == 'connected'
+    assert _events[2].name == 'ready'
+    assert _events[3].name == 'poll'
+    assert _events[4].name == 'text'
+    assert _events[4].text == u'foo'
+    assert _events[5].name == 'binary'
+    assert _events[5].data == b'bar'
+    assert _events[6].name == 'closing'
+    assert _events[7].name == 'disconnected'
+    assert _events[7].graceful
 
 
-def test_echo_no_sni():
-    """Test against public echo server."""
-    try:
-        from lomond import session
-        has_sni = session.HAS_SNI
-        session.HAS_SNI = False
-        ws = lomond.WebSocket('wss://echo.websocket.org')
-        events = []
-        for event in ws.connect(poll=60, ping_rate=0, auto_pong=False):
-            events.append(event)
-            if event.name == 'ready':
-                ws.send_text(u'foo')
-                ws.send_binary(b'bar')
-                ws.close()
-
-        assert len(events) == 8
-        assert events[0].name == 'connecting'
-        assert events[1].name == 'connected'
-        assert events[2].name == 'ready'
-        assert events[3].name == 'poll'
-        assert events[4].name == 'text'
-        assert events[4].text == u'foo'
-        assert events[5].name == 'binary'
-        assert events[5].data == b'bar'
-        assert events[6].name == 'closed'
-        assert events[7].name == 'disconnected'
-        assert events[7].graceful
-    finally:
-        session.HAS_SNI = has_sni
-
-
-def test_echo_poll():
-    """Test against public echo server."""
-    # TODO: host our own echo server
-    ws = lomond.WebSocket('wss://echo.websocket.org')
+def test_echo_poll(local_idle_ws_url):
+    ws = lomond.WebSocket(local_idle_ws_url)
     _events = []
     polls = 0
     for event in ws.connect(poll=1.0, ping_rate=1.0, auto_pong=True):
@@ -74,37 +68,36 @@ def test_echo_poll():
             if polls == 1:
                 ws.session._on_event(events.Ping(b'foo'))
             elif polls == 2:
-                # Covers some lesser used code paths
                 ws.state.closed = True
                 ws.session._sock.close()
+    assert polls >= 2
 
 
-def test_not_ws():
-    """Test against a URL that doesn't serve websockets."""
-    ws = lomond.WebSocket('wss://www.google.com')
-    events = list(ws.connect())
-    assert len(events) == 4
-    assert events[0].name == 'connecting'
-    assert events[1].name == 'connected'
-    assert events[2].name == 'rejected'
-    assert events[3].name == 'disconnected'
-    assert events[3].graceful
+def test_not_ws(local_http_url):
+    ws = lomond.WebSocket(local_http_url.replace('http://', 'ws://'))
+    _events = list(ws.connect())
+    assert len(_events) == 4
+    assert _events[0].name == 'connecting'
+    assert _events[1].name == 'connected'
+    assert _events[2].name == 'rejected'
+    assert _events[3].name == 'disconnected'
+    assert _events[3].graceful
 
 
 class SelectSession(WebsocketSession):
     _selector_cls = selectors.SelectSelector
 
 
-def test_not_ws_select():
+def test_not_ws_select(local_http_url):
     """Test against a URL that doesn't serve websockets."""
-    ws = lomond.WebSocket('wss://www.google.com')
-    events = list(ws.connect(session_class=SelectSession))
-    assert len(events) == 4
-    assert events[0].name == 'connecting'
-    assert events[1].name == 'connected'
-    assert events[2].name == 'rejected'
-    assert events[3].name == 'disconnected'
-    assert events[3].graceful
+    ws = lomond.WebSocket(local_http_url.replace('http://', 'ws://'))
+    _events = list(ws.connect(session_class=SelectSession))
+    assert len(_events) == 4
+    assert _events[0].name == 'connecting'
+    assert _events[1].name == 'connected'
+    assert _events[2].name == 'rejected'
+    assert _events[3].name == 'disconnected'
+    assert _events[3].graceful
 
 
 def test_no_url_wss():

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -2,7 +2,7 @@ import types
 
 import pytest
 
-from lomond.parser import ParseError, Parser
+from lomond.parser import ParseEOF, ParseError, ParseOverflow, Parser
 
 
 def test_parser_reset_is_a_generator():
@@ -32,12 +32,33 @@ def test_eof():
     test_parser = TestParser()
     test_data = [b'foo', b'']
     assert not test_parser.is_eof
-    with pytest.raises(ParseError):
+    with pytest.raises(ParseEOF):
         for data in test_data:
             for _token in test_parser.feed(data):
                 print(_token)
     assert test_parser.is_eof
-    test_parser.feed(b'more')
-    with pytest.raises(ParseError):
-        for data in test_parser.feed('foo'):
+    with pytest.raises(ParseEOF):
+        list(test_parser.feed(b'more'))
+    with pytest.raises(ParseEOF):
+        for data in test_parser.feed(b'foo'):
             print(data)
+
+
+def test_overflow():
+    class TestParser(Parser):
+        def parse(self):
+            data = yield self.read(3)
+            yield data
+
+    test_parser = TestParser()
+    output = []
+    with pytest.raises(ParseOverflow):
+        for data in test_parser.feed(b'foobar'):
+            output.append(data)
+    assert output == [b'foo']
+
+    output = []
+    with pytest.raises(ParseOverflow):
+        for data in test_parser.feed(b'foobar'):
+            output.append(data)
+    assert not output

--- a/tests/test_persist.py
+++ b/tests/test_persist.py
@@ -1,5 +1,6 @@
 from lomond.persist import persist
 from lomond import events
+from lomond.response import Response
 
 
 class FakeEvent(object):
@@ -11,6 +12,16 @@ class FakeWebSocket(object):
     def connect(self, poll=None, ping_rate=None, ping_timeout=None):
         yield events.Connecting('ws://localhost:1234/')
         yield events.ConnectFail('test')
+
+
+def _build_rejected(retry_after):
+    payload = (
+        b'HTTP/1.1 429 Too Many Requests\r\n'
+        b'Retry-After: ' + retry_after + b'\r\n'
+        b'\r\n'
+    )
+    response = Response(payload)
+    return events.Rejected(response, 'rate limited')
 
 
 def persist_testing_helper(mocker, validate_function, websocket_connect=None):
@@ -63,3 +74,81 @@ def test_emulate_ready_event(mocker):
         assert isinstance(_events[2], events.BackOff)
 
     persist_testing_helper(mocker, validate_events, successful_connect)
+
+
+def test_persist_respects_retry_after_delta(mocker):
+    class FakeExitEvent(object):
+        waited = None
+
+        def wait(self, wait_for=None):
+            self.waited = wait_for
+            return True
+
+    def rejected_connect(poll=None, ping_rate=None, ping_timeout=None):
+        yield events.Connecting('ws://localhost:1234')
+        yield _build_rejected(b'12')
+
+    websocket = FakeWebSocket()
+    websocket.connect = rejected_connect
+    exit_event = FakeExitEvent()
+    yielded_events = list(persist(websocket, exit_event=exit_event))
+
+    assert isinstance(yielded_events[1], events.Rejected)
+    assert isinstance(yielded_events[2], events.BackOff)
+    assert yielded_events[2].delay == 12.0
+    assert exit_event.waited == 12.0
+
+
+def test_persist_ignores_invalid_retry_after(mocker):
+    class FakeExitEvent(object):
+        waited = None
+
+        def wait(self, wait_for=None):
+            self.waited = wait_for
+            return True
+
+    def rejected_connect(poll=None, ping_rate=None, ping_timeout=None):
+        yield events.Connecting('ws://localhost:1234')
+        yield _build_rejected(b'not-a-duration')
+
+    websocket = FakeWebSocket()
+    websocket.connect = rejected_connect
+    exit_event = FakeExitEvent()
+    yielded_events = list(persist(
+        websocket,
+        min_wait=5,
+        max_wait=5,
+        exit_event=exit_event
+    ))
+
+    assert isinstance(yielded_events[2], events.BackOff)
+    assert yielded_events[2].delay == 5.0
+    assert exit_event.waited == 5.0
+
+
+def test_persist_retry_after_can_be_disabled(mocker):
+    class FakeExitEvent(object):
+        waited = None
+
+        def wait(self, wait_for=None):
+            self.waited = wait_for
+            return True
+
+    def rejected_connect(poll=None, ping_rate=None, ping_timeout=None):
+        yield events.Connecting('ws://localhost:1234')
+        yield _build_rejected(b'60')
+
+    websocket = FakeWebSocket()
+    websocket.connect = rejected_connect
+    exit_event = FakeExitEvent()
+    yielded_events = list(persist(
+        websocket,
+        min_wait=3,
+        max_wait=3,
+        exit_event=exit_event,
+        respect_retry_after=False
+    ))
+
+    assert isinstance(yielded_events[2], events.BackOff)
+    assert yielded_events[2].delay == 3.0
+    assert exit_event.waited == 3.0

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -1,11 +1,20 @@
 from __future__ import unicode_literals
 
-import os
-import subprocess
 import pytest
 import time
 
 from lomond import WebSocket, proxy
+from socket_fixtures import get_free_port, LocalWebSocketServer, LocalConnectProxy
+
+
+@pytest.fixture(scope='module')
+def ws_url():
+    port = get_free_port()
+    server = LocalWebSocketServer(port)
+    server.start()
+    time.sleep(0.05)
+    yield 'ws://127.0.0.1:{}/echo'.format(port)
+    server.stop()
 
 
 def test_build_request():
@@ -17,7 +26,7 @@ def test_build_request():
         b'Host: ws://example.org\r\n'
         b'Proxy-Connection: keep-alive\r\n'
         b'Connection: keep-alive\r\n'
-        b'Proxy-Authorization:: Basic Zm9v\r\n\r\n'
+        b'Proxy-Authorization: Basic Zm9v\r\n\r\n'
     )
     assert request_bytes == expected
 
@@ -59,48 +68,41 @@ def test_parser_fail_nodata():
             break
 
 
-def test_proxy():
-    proc = subprocess.Popen(['proxy.py', '--port', '8888'])
+def test_proxy(ws_url):
+    proxy_port = get_free_port()
+    proxy_server = LocalConnectProxy(proxy_port)
+    proxy_server.start()
+    proxy_url = 'http://127.0.0.1:{}'.format(proxy_port)
     try:
-        time.sleep(1)
         ws = WebSocket(
-            'wss://echo.websocket.org',
-            proxies={'https': 'http://127.0.0.1:8888'}
+            ws_url,
+            proxies={'http': proxy_url}
         )
-        events = []
+        _events = []
         for event in ws:
-            events.append(event)
+            _events.append(event)
             if event.name == 'ready':
                 ws.close()
 
-        assert len(events) == 6
-        assert events[0].name == 'connecting'
-        assert events[1].name == 'connected'
-        assert events[1].proxy == 'http://127.0.0.1:8888'
-        assert events[2].name == 'ready'
-        assert events[3].name == 'poll'
-        assert events[4].name == 'closed'
-        assert events[5].name == 'disconnected'
+        assert len(_events) == 6
+        assert _events[0].name == 'connecting'
+        assert _events[1].name == 'connected'
+        assert _events[1].proxy == proxy_url
+        assert _events[2].name == 'ready'
+        assert _events[3].name == 'poll'
+        assert _events[4].name == 'closed'
+        assert _events[5].name == 'disconnected'
     finally:
-        os.kill(proc.pid, 3)
+        proxy_server.stop()
 
 
-def test_bad_proxy():
-    proc = subprocess.Popen(['proxy.py', '--port', '8888'])
-    try:
-        time.sleep(0.1)
-        ws = WebSocket(
-            'wss://echo.websocket.org',
-            proxies={'https': 'http://bad.test:8888'}
-        )
-        events = []
-        for event in ws:
-            events.append(event)
-            if event.name == 'ready':
-                ws.close()
-
-        assert len(events) == 2
-        assert events[0].name == 'connecting'
-        assert events[1].name == 'connect_fail'
-    finally:
-        os.kill(proc.pid, 3)
+def test_bad_proxy(ws_url):
+    bad_proxy_port = get_free_port()
+    ws = WebSocket(
+        ws_url,
+        proxies={'http': 'http://127.0.0.1:{}'.format(bad_proxy_port)}
+    )
+    _events = list(ws.connect())
+    assert len(_events) == 2
+    assert _events[0].name == 'connecting'
+    assert _events[1].name == 'connect_fail'

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -391,3 +391,15 @@ def test_run_selector_failure_disconnects(session):
     assert _events[1].name == 'connected'
     assert _events[2].name == 'disconnected'
     assert not _events[2].graceful
+
+
+def test_session_time_uses_monotonic_clock(monkeypatch, session):
+    t = {'now': 100.0}
+
+    def fake_monotonic():
+        return t['now']
+
+    monkeypatch.setattr('lomond.session.monotonic_time', fake_monotonic)
+    session._on_ready()
+    t['now'] = 103.5
+    assert session.session_time == 3.5

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -64,6 +64,9 @@ class FakeWebSocket(object):
 
     sent_close_time = -100
 
+    def _emit_trace(self, *args, **kwargs):
+        return
+
     def send_pong(self, data):
         raise errors.WebSocketClosed('sorry')
 
@@ -86,11 +89,24 @@ class FakeBrokenSelector(object):
     def __init__(self, socket):
         pass
 
+    def wait(self, max_bytes, timeout):
+        raise IOError('broke')
+
     def wait_readable(self, timeout):
         raise IOError('broke')
 
     def close(self):
         pass
+
+
+class FakeSSLContext(object):
+    def __init__(self, marker='context'):
+        self.marker = marker
+        self.calls = []
+
+    def wrap_socket(self, sock, server_hostname=None):
+        self.calls.append((sock, server_hostname))
+        return (self.marker, sock, server_hostname)
 
 
 def test_write_without_sock_fails(session):
@@ -223,7 +239,7 @@ def test_that_on_ping_responds_with_pong(session, mocker):
 
     session._send_pong(events.Ping(b'\x00'))
 
-    assert send_pong.called_with(b'\x00')
+    send_pong.assert_called_with(b'\x00')
 
 
 def test_error_on_close_socket(caplog, session):
@@ -322,3 +338,56 @@ def test_check_close_timeout(session):
     session._check_close_timeout(10, 19)
     with pytest.raises(_ForceDisconnect):
         session._check_close_timeout(10, 21)
+
+
+def test_wrap_socket_uses_default_context(monkeypatch, session):
+    fake_ctx = FakeSSLContext(marker='default')
+    called = {}
+
+    def create_default_context(**kwargs):
+        called.update(kwargs)
+        return fake_ctx
+
+    monkeypatch.setattr('lomond.session.HAS_SNI', True)
+    monkeypatch.setattr('ssl.create_default_context', create_default_context)
+    session.websocket.ssl_verify = True
+    session.websocket.ssl_cafile = '/tmp/ca.pem'
+    session.websocket.ssl_context = None
+
+    wrapped = session._wrap_socket(FakeSocket(), 'example.com')
+    assert wrapped[0] == 'default'
+    assert called == {'cafile': '/tmp/ca.pem'}
+    assert fake_ctx.calls[0][1] == 'example.com'
+
+
+def test_wrap_socket_uses_unverified_context(monkeypatch, session):
+    fake_ctx = FakeSSLContext(marker='unverified')
+    called = {'count': 0}
+
+    def create_unverified_context():
+        called['count'] += 1
+        return fake_ctx
+
+    monkeypatch.setattr('lomond.session.HAS_SNI', False)
+    monkeypatch.setattr('ssl._create_unverified_context', create_unverified_context)
+    session.websocket.ssl_verify = False
+    session.websocket.ssl_cafile = None
+    session.websocket.ssl_context = None
+
+    wrapped = session._wrap_socket(FakeSocket(), 'example.com')
+    assert wrapped[0] == 'unverified'
+    assert called['count'] == 1
+    assert fake_ctx.calls[0][1] is None
+
+
+def test_run_selector_failure_disconnects(session):
+    def connect_success():
+        return FakeSocket(), None
+
+    session._connect = connect_success
+    session._selector_cls = FakeBrokenSelector
+    _events = list(session.run())
+    assert _events[0].name == 'connecting'
+    assert _events[1].name == 'connected'
+    assert _events[2].name == 'disconnected'
+    assert not _events[2].graceful

--- a/tests/test_websocket.py
+++ b/tests/test_websocket.py
@@ -79,11 +79,27 @@ def test_init(websocket):
     assert len(b64decode(websocket.key)) == 16
     assert websocket.session is None
     assert isinstance(websocket.stream, WebsocketStream)
+    assert websocket.ssl_verify is True
+    assert websocket.ssl_cafile is None
+    assert websocket.ssl_context is None
 
 
 def test_init_with_query():
     ws = WebSocket('ws://example.com/resource?query')
     assert ws.resource == '/resource?query'
+
+
+def test_init_ssl_options():
+    context = object()
+    ws = WebSocket(
+        'wss://example.com/resource',
+        ssl_verify=False,
+        ssl_cafile='/tmp/cafile.pem',
+        ssl_context=context
+    )
+    assert ws.ssl_verify is False
+    assert ws.ssl_cafile == '/tmp/cafile.pem'
+    assert ws.ssl_context is context
 
 
 def test_repr(websocket):
@@ -151,6 +167,15 @@ def test_connect(websocket_with_fake_session):
     # Session object.
     assert isinstance(websocket.session, FakeSession)
     assert websocket.session.run_called
+
+
+def test_trace_callback():
+    records = []
+    ws = WebSocket('ws://example.com', trace=records.append)
+    ws._emit_trace('unit_test', foo='bar')
+    assert records == [
+        {'stage': 'unit_test', 'url': 'ws://example.com', 'foo': 'bar'}
+    ]
 
 
 def test_calling_close_sets_is_closing_flag(websocket_with_fake_session):

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,6 @@
 [tox]
-envlist = clean,py{27,35,36}{,-wsaccel},coverage
+envlist = clean,py{27,35,36,37,38,39,310,311,312,313}{,-wsaccel},coverage
+skip_missing_interpreters = true
 
 [testenv:clean]
 deps = coverage
@@ -14,7 +15,7 @@ commands =
     rm -Rf {toxinidir}/reports
 
 [testenv]
-setenv = PYHONPATH={toxinidir}/tests
+setenv = PYTHONPATH={toxinidir}/tests
 deps =
     proxy.py
     pytest


### PR DESCRIPTION
## Summary
- harden websocket parser/stream/session behavior (EOF/overflow handling, safer frame length unpacking, unknown stream exception handling, secure TLS defaults and structured tracing)
- replace network-dependent live/proxy tests with deterministic local socket fixtures and add fuzz-style parser/frame coverage plus reconnect/failure-injection tests
- expand automation: modern Python CI matrix (3.8-3.13), legacy CI matrix (2.7/3.5/3.6/3.7 in GitHub-hosted Docker), and OIDC-based PyPI Trusted Publisher workflow
- add troubleshooting and operational documentation (trace cookbook, failure signatures, Retry-After reconnect behavior, TPM setup)

## Test plan
- [x] `.venv/bin/pytest tests --ignore=tests/test_integration.py`
- [x] `.venv/bin/pytest tests/test_proxy.py tests/test_live.py tests/test_fuzzing.py tests/test_persist.py tests/test_session.py`
- [x] `.venv/bin/pytest tests/test_parser.py tests/test_frame_parser.py tests/test_stream.py tests/test_websocket.py tests/test_fuzzing.py`