### PR TITLE
Update README badges and changelog for CI migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [0.3.4] - 2026-07-06
 
+### Changed
+
+- README CI badges now point to GitHub Actions workflows (CircleCI removed)
+
 ### Added
 
 - TLS configuration controls on `WebSocket`: `ssl_verify`, `ssl_cafile`,
@@ -32,6 +36,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Corrected typo in tox `PYTHONPATH` configuration
 - Corrected broken `test_session` mock assertion (`assert_called_with`)
 - Proxy auto-detection now respects lowercase env vars (`http_proxy`, `https_proxy`)
+- Stabilized local websocket fixture close handshake to avoid intermittent
+  non-graceful disconnect assertions in CI
 
 
 ## [0.3.2] - 2018-07-04

--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@ Tranquil WebSockets for Python.
 [![PyPI version](https://badge.fury.io/py/lomond.svg)](https://pypi.org/project/lomond/)
 [![PyPI](https://img.shields.io/pypi/pyversions/lomond.svg)](https://pypi.org/project/lomond/)
 [![Coverage Status](https://coveralls.io/repos/github/wildfoundry/dataplicity-lomond/badge.svg?branch=master)](https://coveralls.io/github/wildfoundry/dataplicity-lomond?branch=master)
-[![CircleCI](https://circleci.com/gh/wildfoundry/dataplicity-lomond/tree/master.svg?style=svg)](https://circleci.com/gh/wildfoundry/dataplicity-lomond/tree/master)
+[![CI (modern)](https://github.com/wildfoundry/dataplicity-lomond/actions/workflows/ci-modern.yml/badge.svg?branch=master)](https://github.com/wildfoundry/dataplicity-lomond/actions/workflows/ci-modern.yml)
+[![CI (legacy)](https://github.com/wildfoundry/dataplicity-lomond/actions/workflows/ci-legacy-py27.yml/badge.svg?branch=master)](https://github.com/wildfoundry/dataplicity-lomond/actions/workflows/ci-legacy-py27.yml)
 
 Lomond is a Websocket client which turns a websocket connection in to
 an orderly stream of _events_. No threads or callbacks necessary.


### PR DESCRIPTION
## Summary
- replace the deprecated CircleCI badge in `README.md` with GitHub Actions modern/legacy CI badges
- update the `0.3.4` changelog to record the CI badge migration and the close-handshake test stabilization

## Test plan
- [x] Verify README badge links render to active GitHub Actions workflows
- [x] Verify changelog entries accurately reflect shipped changes